### PR TITLE
BIG CHANGES: Change into a diagnosis-first network command center

### DIFF
--- a/PLAN-REVIEW-LOG.md
+++ b/PLAN-REVIEW-LOG.md
@@ -1,0 +1,210 @@
+# Plan Review Log: network-doctor — unify external network tools behind a diagnosis-first TUI
+Act 1 (grill) complete — plan locked with the user. MAX_ROUNDS=5.
+
+## Round 1 — Codex
+- Sequential skip conflicts with diagnosis rules: a DNS failure skips the independent Internet TCP probe, preventing "DNS-only failure" diagnosis; fix: model explicit dependencies and run Internet TCP independently of DNS.
+- Interface, IP, and route probes may pass using different interfaces, producing a fictitious healthy path; fix: identify the route-selected interface/source address and validate one coherent path.
+- /proc/net/route ignores policy routing and VRFs, and a default route is unnecessary for an on-link target; fix: determine effective routing for each probe destination via netlink or a UDP-connect source/route lookup.
+- Bare-host default-port behavior is undefined, while scheme/explicit-port conflicts such as https://host:80 are ambiguous; fix: define a typed target parser with explicit precedence and table-driven cases.
+- Resolving separately in DNS, TCP, TLS, and HTTP probes can test different load-balanced addresses; fix: resolve once per run and pass the selected IP through probes while preserving SNI and HTTP Host.
+- 1.1.1.1:443 is a single-provider reachability oracle and will falsely fail on proxy-only or selectively filtered networks; fix: classify it narrowly as direct TCP reachability or probe multiple configurable endpoints.
+- "Raw output verbatim" permits external tools or remote servers to inject ANSI/OSC terminal control sequences; fix: sanitize control bytes before display while retaining bounded original bytes only for export.
+- Captured stdout/stderr and Bubble Tea messages are unbounded, so ss, hostile HTTP headers, or noisy tools can exhaust memory and freeze the UI; fix: impose per-stream byte/line/message limits and visibly mark truncation.
+- ToolOutputMsg lacks stdout/stderr identity, yet ToolResult requires separate streams; fix: add a stream field and make the Bubble Tea update loop the sole owner of bounded buffers.
+- Pipe completion ordering is underspecified, allowing cmd.Wait()/done delivery before both readers drain their final output; fix: drain both pipes concurrently, wait for both readers, then emit exactly one terminal job message.
+- CommandContext only guarantees termination of the direct process, not descendants; fix: launch jobs in their own process group and terminate the group on cancel or timeout.
+- Job-state transitions do not define how user cancel versus deadline versus nonzero exit is classified; fix: centralize terminal-state selection using context cause, wait error, and exit status with exactly-once completion.
+- Starting another job, rerunning the chain, closing the pane, and q/ctrl+c behavior conflict with the one-active-job rule; fix: specify a state-dependent key map and reject or explicitly cancel-and-await the old job.
+- Facts are untyped strings without target, generation, timestamp, or job identity, so stale reruns can contaminate a new diagnosis; fix: scope typed facts to target and generation and replace facts atomically per completed job.
+- The planned curl -vI command does not provide a stable total-time field and parsing depends on locale/version; fix: use curl -q --write-out with a machine-readable format and force LC_ALL=C.
+- User curl configuration can alter the supposedly bounded invocation; fix: put -q first and explicitly constrain protocols, redirects, proxy behavior, and output.
+- Native HTTP HEAD behavior is undefined for redirects, unsupported HEAD responses, connection reuse, and non-default ports; fix: use a fresh configured transport, disable redirects/reuse, and build requests from the parsed scheme/host/port.
+- Toolbox facts can change the diagnosis, but the plan does not define recomputation, conflict precedence, or evidence provenance; fix: define deterministic native-versus-tool evidence precedence and recompute only from current-generation data.
+- Exit semantics are missing for Skip, toolbox-only mode, failed jobs, canceled jobs, and early pane closure; fix: publish an explicit exit-code table and test every terminal UI state.
+- Export may disclose socket ownership, local addresses, routes, and raw remote output, with no permission or overwrite policy; fix: create reports with mode 0600, require explicit overwrite, and warn or redact sensitive sections.
+- The test plan omits the highest-risk behavior: real subprocess cancellation, pipe draining, stale messages, scanner limits, and oversized output; fix: add helper-process integration tests and run them under go test -race.
+
+VERDICT: REVISE
+
+### Claude's response
+Accepted nearly all 21 findings; rewrote PLAN.md v2. Notable changes + the few where I took a simpler path:
+
+ACCEPTED as-is:
+- Dependency-graph chain (Internet TCP independent of DNS) — replaces linear skip.
+- Single resolution per run; chosen IP threaded through TCP/TLS/HTTP; SNI/Host preserved.
+- Typed table-driven target parser with explicit precedence (explicit port > scheme default); validation regex.
+- ANSI/OSC/control-byte sanitization before render (tools AND remote banners) — new sanitize.go.
+- Bounded per-stream byte/line caps + max in-flight messages; byte-capped reader (not bare bufio.Scanner's 64KB line cap) + truncation marker.
+- ToolOutputMsg gains {JobID, Generation, Stream}; Update loop sole owner of bounded buffers.
+- Drain-both-readers (WaitGroup) → cmd.Wait() → exactly-one terminal message.
+- Process group (Setpgid) + kill(-pgid) on cancel/timeout to reap descendants (mtr-packet).
+- Centralized terminal-state classification via context.Cause + wait error + exit code, exactly-once.
+- State-dependent keymap: new tool while running = cancel-and-await; q/ctrl+c cancels running job first (no orphan).
+- Typed generation-scoped Facts (Target/Generation/JobID/At); atomic per-job replace; stale dropped.
+- curl facts via LC_ALL=C curl -q -sS -w '<machine format>' --max-redirs 0 --noproxy '*' --proto '=https,http'.
+- Native HTTP HEAD: fresh non-reusing transport, redirects off, from parsed scheme/host/port; 405/3xx = responded.
+- Explicit exit-code table (0 pass / 1 fail or early quit / 0 toolbox / 2 internal); Skip != failure on its own.
+- Export: mode 0600, timestamped (no clobber), sanitized, header warning about local network disclosure.
+- Helper-process integration tests under go test -race for cancel/timeout/drain/stale-msg/caps.
+
+ACCEPTED but with a SIMPLER resolution than Codex proposed:
+- "Coherent path / policy-routing / VRF": adopted the lightweight UDP-connect source/route lookup (net.Dial udp → LocalAddr) Codex offered as the alternative, instead of full netlink. Reports the kernel-chosen iface/source for the destination; defaultRoute() demoted to supplementary display, not a hard gate for on-link targets.
+- "1.1.1.1:443 single oracle": kept a tiny ordered endpoint list (1.1.1.1:443, 8.8.8.8:443, first-wins) labeled honestly as "direct TCP egress"; diagnosis wording acknowledges proxy-only/filtered nets. Not fully configurable in v1 (flag/env deferred).
+- "Toolbox facts change diagnosis — define precedence/recompute": removed the feedback path entirely — diagnosis is computed ONLY from current-generation native probe state; tool facts are display-only evidence. Simpler than a native-vs-tool precedence engine and matches the locked layering.
+
+REJECTED: none outright.
+
+## Round 2 — Codex
+Most prior findings addressed. Remaining material issues:
+- DAG inconsistent: path discovery needs resolved IP yet precedes DNS; Internet TCP shouldn't depend on target route; fix: separate target-path and direct-egress-path nodes, target path depends on DNS.
+- IP literals have no defined DNS/dependency behavior; fix: bypass DNS for IPv4 literals, seed resolved-IP directly.
+- Explicit schemes semantically ignored (https://host:80 → plaintext, http://host:443 → TLS); fix: explicit scheme selects protocol, port selects only endpoint; infer protocol from port only when no scheme.
+- net.IP accepts IPv6 despite out-of-scope; fix: reject literals where To4() is nil.
+- UDP route discovery doesn't model TCP policy rules / VRFs; fix: narrow the claim or use TCP-specific/netlink lookup.
+- No-argument generic-chain behavior disappeared from the CLI spec; fix: preserve it or define no-target as usage error.
+- Banner reads memory-unbounded if server streams without newline; fix: deadline + strict byte-limited reader.
+- Native HTTP response headers remotely controlled/large; fix: set conservative MaxResponseHeaderBytes.
+- LC_ALL=C can't be an exec arg-slice token; fix: set via cmd.Env, shell-quote only the display string.
+- Bounded streaming overflow undefined; blocked reader sends could prevent drain/terminal delivery; fix: bounded nonblocking queue, keep draining/discarding after caps, report dropped output.
+
+VERDICT: REVISE
+
+### Claude's response
+Accepted all 9 — targeted edits to PLAN.md v3:
+- Split the DAG into a direct-egress path (Interface→egress discovery→Internet TCP, DNS-independent) and a target path (Interface→DNS→target-path discovery→Target TCP→protocol rows); target-path discovery now correctly follows DNS.
+- IPv4-literal targets: DNS row = Skip (N/A), resolved-IP seeded directly.
+- Target parser now has two independent axes: explicit scheme selects protocol; port selects endpoint; port-inference only when no scheme. https://host:80 → TLS+HTTP on 80; http://host:443 → plaintext on 443.
+- Reject IPv6 literals (To4()==nil → error).
+- UDP route discovery claim narrowed to ordinary destination-based routing; no VRF/TCP-policy guarantee (netlink = later upgrade).
+- Restored no-arg generic local+internet chain in the CLI spec.
+- Banner grabs: hard deadline + io.LimitReader (~1KB).
+- Native HTTP HEAD: conservative MaxResponseHeaderBytes on the dedicated transport.
+- curl: LC_ALL=C via cmd.Env (not argv); display string shell-quoted for humans only.
+- Streaming: bounded non-blocking queue; readers keep draining+discarding after caps (dropped-bytes counter shown) so a full queue can't deadlock drain/terminal delivery.
+
+REJECTED: none.
+
+## Round 3 — Codex
+Prior findings mostly addressed. Remaining/new:
+- Multiple A records resolved once but only one chosen IP tested → false failures; fix: retain all A records, try each for Target TCP, pin first successful IP for protocol probes.
+- Egress path discovery targets one endpoint while Internet TCP may succeed against another via a different route; fix: report path per attempted endpoint or use the successful connection's local address.
+- Shared Interface/IP row ambiguous when target and egress use different interfaces (VPN split routing); fix: show path-specific source/interface rows.
+- Queue ordering doesn't guarantee buffered output reaches Bubble Tea before the terminal message; fix: single FIFO with terminal event enqueued last.
+- --toolbox [<host>] permits no host but plan says tools run against the parsed target; fix: define local-tools-only no-target toolbox or require a target.
+- curl adapter dropped -I/--head, so it does a GET (large transfer); fix: add --head.
+- Skip is prereq-failure but also used for IP-literal DNS N/A; fix: add NotApplicable state.
+- "Base" ordering still puts route before DNS despite target route discovery needing the resolved IP; fix: replace linear list with the two-path DAG ordering.
+
+VERDICT: REVISE
+
+### Claude's response
+Accepted all 7 — edits to PLAN.md v4:
+- Resolution: retain all A records, Target TCP tries each, pins first successful IP for protocol probes.
+- Dropped separate egress pre-discovery; egress and target source/iface now derived from the winning connection's LocalAddr.
+- Path-specific source/interface rows when egress and target paths differ (VPN split routing).
+- Streaming: output + terminal event on one ordered FIFO, terminal enqueued last (no stale-drop of final lines).
+- --toolbox with no host = local-tools-only (ip/ss enabled; target-dependent tools greyed until a target is given).
+- curl fact invocation restored --head (evidence-only, no large GET).
+- Added NotApplicable state (distinct from Skip); IP-literal DNS row = NotApplicable; not counted as failure.
+- Removed the stale linear "Base:" ordering; protocol-rows section now references the two-path DAG explicitly.
+
+REJECTED: none.
+
+## Round 4 — Codex
+Most round-3 findings addressed. Remaining:
+- Bounded nonblocking FIFO can drop its terminal event when full → job stuck running; fix: reserve capacity / guaranteed terminal send after queued output drains.
+- Sequential address attempts can consume the whole deadline on the first dead A record/endpoint; fix: staggered parallel dialing or per-address time budgets.
+- Path discovery contradictory: some sections use successful TCP LocalAddr, others still specify UDP-connect; fix: TCP LocalAddr on success + per-destination UDP fallback on failure, remove stale alternatives.
+- Successful-connection-only path reporting gives no source/interface evidence for failures (where diagnosis needs it most); fix: bounded route/source discovery for failed destinations.
+- No-target generic chain still promises an IP/route row though direct-egress path has no separate route node; fix: define the exact generic DAG + row sources.
+- File layout still says "tri-state"; fix: Pass/Fail/Skip/NotApplicable.
+- Unresolved toolbox open question contradicts the new local-tools-only mode; fix: remove the stale open question.
+- Terminal sanitization is security-critical but has no tests; fix: table/fuzz tests for split ANSI/OSC, C0/C1, long sequences, malformed UTF-8.
+
+VERDICT: REVISE
+
+### Claude's response
+Accepted all 8 — edits to PLAN.md v5:
+- FIFO: terminal event never dropped — reserved slot / guaranteed send after output drains; only output lines are droppable. No more stuck JobRunning.
+- Per-destination time budget (~deadline/addr-count) for both target A records and egress endpoints; staggered parallel marked as later optimization.
+- Unified path-discovery rule: success → conn.LocalAddr; failure/pre-connect → UDP-connect fallback; one rule for egress + target; removed stale UDP-only phrasing.
+- Failed destinations still get path identity via the UDP-connect fallback (evidence where diagnosis needs it most).
+- Specified the exact no-target generic DAG (Interface→Internet TCP→DNS to probe host) with row sources; default route = supplementary display, not a node.
+- File layout updated to four-state (Pass/Fail/Skip/NotApplicable).
+- Removed the stale --toolbox open question (now defined as local-tools-only mode in the CLI section).
+- Added security-critical sanitization tests (table+fuzz: split ANSI/OSC/CSI, C0/C1, over-long sequences, malformed UTF-8) and an overflow-keeps-terminal-event integration test.
+
+REJECTED: none.
+
+## Round 5 — Codex (MAX_ROUNDS reached)
+Round-4 findings largely addressed. Remaining:
+- DAG has no concrete execution/data contract; DNS must publish addresses, Target TCP the pinned IP/source; fix: typed ProbeResult outputs, dependency IDs, Update-owned generation-scoped run state.
+- Existing Result schema can't represent multiple attempts/selected IP/source/timings/failure classes without parsing display strings; fix: structured probe evidence + separately rendered detail text.
+- No-target chain shows Internet TCP → DNS while calling DNS independent → could skip DNS after egress failure; fix: make DNS and Internet TCP siblings depending only on Interface.
+- All-address-fail UDP fallback selection ambiguous across multiple destination routes; fix: bounded per-address attempt record + explicit fallback choice.
+- File layout & key decisions still describe UDP-only discovery and "one IP"; fix: update to the final hybrid, multi-address rule.
+- Markdown export sanitizes terminal controls but not Markdown/HTML/remote-image injection; fix: escaped code blocks, raw HTML disabled.
+- Tests omit the DAG scheduler + multi-address selection; fix: add sibling independence, dependency skips, generation resets, per-address budgeting, pinning, all-address failure.
+
+VERDICT: REVISE
+
+### Claude's response
+Accepted all 7 — final edits to PLAN.md:
+- Added a "Probe data contract" section: typed ProbeResult (ID, Status, FailClass, Addrs, SelectedIP, Source/Iface, Attempts, RTT, derived Detail/Fix) replacing string-only Result; Update-owned generation-scoped map[ProbeID]ProbeResult; DAG scheduler with declared dependency IDs.
+- Fixed the no-target DAG: DNS and Internet TCP are now siblings depending only on Interface (egress failure no longer skips DNS).
+- All-address failure: bounded per-address Attempt record; deterministic fallback summary (first address's UDP-connect path), full attempt list in detail pane.
+- Reworded Key decision #3, file layout, and phasing to the hybrid TCP-first + multi-address rule (removed "UDP-only"/"one IP").
+- Export hardened against Markdown/HTML/remote-image injection: sanitized AND fenced code blocks with raw HTML disabled.
+- Added DAG-scheduler + multi-address tests (sibling independence, dependency skips, generation reset, per-address budgeting, IP pinning, all-address failure).
+
+REJECTED: none. Loop terminated at MAX_ROUNDS=5; every round's findings were incorporated. Remaining critiques were incremental spec-detail, not opposing positions — see Resolution.
+
+## Round 6 — Codex (user requested rounds past MAX)
+Round-5 findings addressed; new material issues:
+- DAG runs nodes only when deps are Pass, so an IP literal's DNS=NotApplicable blocks Target TCP; fix: separate resolution-output node or treat applicable NotApplicable deps as satisfied.
+- "Update-owned" run state may be read by probe goroutines while Update writes siblings → map race; fix: pass immutable dependency snapshots into each probe command.
+- LocalAddr() gives source IP+port, not interface name; fix: map source IP to interface, represent ambiguous/no-match explicitly.
+- Fenced Markdown injectable if attacker output contains the closing fence; standalone report can't enforce raw-HTML-disabled; fix: dynamically longer fences or indent every untrusted line as code.
+- Terminal classification has no precedence when a process exits successfully as its context expires; fix: Wait()==nil → Done, consult context.Cause only on Wait error.
+
+VERDICT: REVISE
+
+### Claude's response
+Accepted all 5:
+- Dependency satisfaction redefined around required OUTPUT, not row status: Pass or applicable-NotApplicable-with-output satisfies dependents; IP-literal DNS=NotApplicable (Addrs/SelectedIP seeded) no longer blocks Target TCP; Fail (no output) → dependents Skip.
+- Map race removed: shared map read/written only in Update; each probe's tea.Cmd closure captures an immutable snapshot of just its dependency outputs.
+- Path discovery: LocalAddr gives source IP; map IP→iface via Interfaces/InterfaceAddrs; ambiguous and no-match are explicit states.
+- Export: switched from ``` fences to 4-space-indented code blocks (no closing delimiter to inject); dropped the unenforceable "raw HTML disabled" claim.
+- Terminal classification: Wait()==nil → Done (success wins over a simultaneous deadline); context.Cause consulted only on Wait error.
+
+REJECTED: none.
+
+## Round 7 — Codex
+Round-6 findings addressed. One material lifecycle gap:
+- Pressing r during an active tool job is undefined; bumping the shared generation can stale-drop its terminal event and leave job state stuck; fix: disable r while a job runs or cancel-and-await it before rerunning, and test the transition.
+
+VERDICT: REVISE
+
+### Claude's response
+Accepted. State-dependent keymap now requires cancel-and-await before any state-changing key while a job runs: r cancels-and-awaits the job FIRST, then bumps generation + restarts the chain (never bump generation mid-job); new-tool and q/ctrl+c already covered. Added a keymap-during-job test (r/new-tool/q cancels-and-awaits, no stale terminal event, no stuck JobRunning, no orphan).
+
+REJECTED: none.
+
+## Round 8 — Codex
+Stale-generation gap addressed; one concurrency clarification:
+- cancel-and-await must not block Bubble Tea's Update (which consumes the terminal event); fix: store a pending action, return immediately, keep consuming job events, execute on the matching terminal event, with defined handling for additional keys while cancellation is pending.
+
+VERDICT: REVISE
+
+### Claude's response
+Accepted. Replaced "cancel-and-await" with a non-blocking pending-action model: a state-changing key while a job runs calls cancel() (non-blocking), stores pendingAction, returns immediately; Update keeps consuming events; pendingAction (startTool/rerun/quit) executes on the job's terminal event; generation bumped only when rerun runs (never mid-job); further keys replace pendingAction (last-write-wins), cancel idempotent. Update never blocks → no deadlock.
+
+REJECTED: none.
+
+## Round 9 — Codex
+The pending-action model resolves the round-eight deadlock and generation lifecycle issue. No new material flaws found; the plan is sound enough to implement.
+
+VERDICT: APPROVED
+
+---
+CONVERGED at round 9. Findings per round: 21, 9, 7, 8, 7, 5, 1, 1, 0. Total 49 raised, 49 incorporated, 0 rejected outright (3 resolved with a simpler path than Codex proposed).

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,355 @@
+# Plan: network-doctor — unify external network tools behind a diagnosis-first TUI
+_Locked via grill — by Claude + mplaczek. Revised after Codex round 1._
+
+## Goal
+Turn network-doctor from a flat in-process check list into a **command center**: a
+diagnosis-first TUI whose home screen runs short, native, rootless, protocol-aware
+probes ("where does the connection break?"), and whose external tools (ping, mtr,
+traceroute, dig, curl, ss, ip) run as **cancellable streaming jobs** on demand for
+proof/drill-down. The killer feature is the plain-English diagnosis, not raw tool
+output. External tools produce *evidence*; native probes produce the *core
+diagnosis*; the diagnosis engine *explains* it. We are not replacing ping/mtr/dig —
+we are the layer that knows which one to run, when, and how to read it.
+
+## Approach
+
+### Architecture — three layers
+1. **Native probes** (in-process Go, short, app-owned, rootless) — the chain + the
+   sole input to the diagnosis. RTT = TCP-connect handshake time (no ICMP, no root,
+   no parsing). DNS timing via `net.Resolver`, TLS timing via `tls.Dialer`.
+2. **Tool adapters** (external, async streaming jobs) — wrap a CLI, stream output,
+   extract a few stable typed `Fact`s after completion, keep bounded raw output.
+   **Tool facts are display-only evidence; they never feed back into the home
+   diagnosis** (simpler than a native-vs-tool precedence engine — addresses Codex's
+   recomputation/provenance concern by removing the feedback path entirely).
+3. **Diagnosis engine**: computes the verdict **only from current-generation native
+   probe state**. First-fail ordering + combination rules (DNS ok + Internet TCP ok +
+   Target TCP fail → "remote port/firewall/VPN").
+
+### Native chain — dependency graph, not a linear skip
+Probes form a DAG with **two distinct paths** so independent probes still run when an
+unrelated sibling fails (fixes "DNS failure hides that the internet is up"):
+
+- **Direct-egress path** (independent of DNS/target): `Interface up` → `Internet TCP`
+  (direct egress, endpoint list, first connect wins). The egress source/interface is
+  read from the **winning connection's `LocalAddr`** (not a separate pre-discovery
+  against one endpoint — different endpoints can take different routes). Always runs so
+  we can report "DNS broken, internet fine."
+- **Target path** (needs the resolved IP, so it comes *after* DNS): `Interface up` →
+  `DNS lookup` (resolves target) → `Target TCP` → protocol rows. The target
+  source/interface is read from the winning Target-TCP connection's `LocalAddr`.
+
+So the target path depends on DNS, and `Internet TCP` never depends on the target's
+route — the two earlier-conflated nodes are split, and path identity is derived from the
+actual successful connection rather than a pre-probe.
+
+**IP-literal targets bypass DNS.** If the target is an IPv4 literal, the `DNS lookup`
+row is `NotApplicable` (literal) and the resolved-IP state is seeded directly.
+
+**Resolution & multiple A records.** For hostname targets, resolve once and **retain
+all A records**; `Target TCP` tries each until one connects, then **pins the first
+successful IP** for the protocol probes (TLS/HTTP) — a single unreachable CDN IP no
+longer causes a false failure. To stop one dead IP eating the whole deadline, each
+address gets a **per-destination time budget** within the overall `ctx` deadline
+(budget ≈ deadline / addr-count, floored); staggered parallel ("happy eyeballs") dialing
+is a later optimization. Same per-endpoint budgeting applies to the egress endpoint list.
+SNI = original host; HTTP `Host` = original host.
+
+**Path-specific source rows.** The egress path and target path can use *different*
+interfaces (VPN split routing). When they differ, show path-specific source/interface
+rows rather than one ambiguous shared row.
+
+### Probe data contract (replaces the string-only `Result`)
+The current `Result{Status, Detail, Fix}` can't carry multiple connection attempts, the
+selected IP, source/interface, timings, or a failure class without parsing display
+strings. Replace it with a structured, typed contract that the diagnosis engine and
+renderer consume separately:
+```go
+type ProbeID string                 // stable node id, e.g. "dns","target_tcp"
+type FailClass int                  // None|Timeout|Refused|NoRoute|DNSFail|TLSFail|...
+type Attempt struct { IP net.IP; Dur time.Duration; Err error }
+type ProbeResult struct {
+    ID         ProbeID
+    Status     Status                // Pass|Fail|Skip|NotApplicable
+    Fail       FailClass
+    Addrs      []net.IP              // DNS publishes all A records here
+    SelectedIP net.IP               // Target TCP publishes the pinned IP
+    Source     net.IP; Iface string // from winning conn LocalAddr / UDP fallback
+    Attempts   []Attempt             // bounded per-address record (see below)
+    RTT        time.Duration
+    Detail     string                // human render text, derived — never parsed back
+    Fix        string
+}
+```
+- **Run state is Update-owned + snapshot-passed (no map race):** the
+  `map[ProbeID]ProbeResult` for the current generation is read/written **only** inside
+  `Update` (single goroutine). A probe's `tea.Cmd` closure captures an **immutable
+  snapshot** of just the dependency outputs it needs (e.g. the resolved `Addrs`) — probe
+  goroutines never touch the shared map while Update writes sibling results. A new
+  generation (rerun) starts an empty map; stale results never leak (existing `generation`
+  guard).
+- **DAG scheduler — satisfaction is about required output, not row status:** each node
+  declares dependency `ProbeID`s; a dep is **satisfied** when its required output is
+  present, which is `Pass` **or** an applicable `NotApplicable` that still produced the
+  output. So an IP-literal target (`DNS = NotApplicable` but `Addrs`/`SelectedIP` seeded)
+  **does not block Target TCP**. A dep that `Fail`ed (no output) makes dependents `Skip`.
+  An independent sibling is never blocked by an unrelated failure.
+- **All-address failure:** `Attempts` keeps a **bounded** record per A record/endpoint
+  (IP, duration, error). When *every* address fails, the summarized fallback path is
+  chosen deterministically: the source/iface for the **first** address's UDP-connect
+  fallback, with the per-address attempt list available in the detail pane.
+
+**Coherent path (no fictitious healthy path) — single rule.** Path identity (source IP +
+interface) for a destination is determined as:
+1. **On a successful TCP connect** → read the winning `conn.LocalAddr()` (ground truth).
+2. **On failure (or before any connect, incl. failed destinations where the diagnosis
+   needs the path most)** → fall back to a UDP "connect" (`net.Dial("udp", dst)` sends no
+   packets) and read its `LocalAddr`.
+This one rule is used for both the egress path and the target path; there is no separate
+pre-discovery node. `LocalAddr()` yields a source **IP** (and port), not an interface
+name — map that source IP back to an interface via `net.Interfaces()`/`InterfaceAddrs()`;
+represent "ambiguous (IP on multiple ifaces)" and "no match" as explicit states, not a
+guessed name. Narrow claim: it models ordinary **destination-based** routing only —
+no guarantee under TCP-specific policy rules or VRFs (netlink lookup = later upgrade).
+On-link targets need no default route; `/proc/net/route`'s `defaultRoute()` is kept only
+as supplementary display ("default route via X"), never a hard gate.
+
+**Internet TCP probe.** Try a small ordered endpoint list (`1.1.1.1:443`,
+`8.8.8.8:443`) — first connect wins. Labeled honestly as **"direct TCP egress"**, and
+the diagnosis wording acknowledges that proxy-only/filtered networks can fail this while
+real (proxied) connectivity works. Endpoints overridable via flag/env later.
+
+Status enum = `Pass / Fail / Skip / NotApplicable` (Warn + mtr route-quality deferred).
+`Skip` = a *prerequisite* failed (an independent probe is never Skipped because an
+unrelated sibling failed). `NotApplicable` = the probe doesn't apply at all (e.g. DNS on
+an IP literal, or a protocol row absent for this port) — distinct from a skipped-due-to-
+failure row and not counted as a failure.
+
+### Protocol rows
+The chain follows the **two-path DAG** above (egress path: Interface→Internet TCP;
+target path: Interface→DNS→Target TCP), not a single linear list. Protocol rows append
+to the target path. Protocol selection: explicit scheme wins; otherwise infer from the
+effective port:
+- `:443 / :8443` → TLS handshake → HTTP HEAD
+- `:80` → HTTP HEAD
+- `:22` → SSH banner grab (native: connect, read first line)
+- `:25 / :587` → SMTP banner grab (native, same shape)
+- other → stop at Target TCP ("no protocol-specific check selected")
+
+**Banner grabs** read under a hard deadline **and** a strict byte limit
+(`io.LimitReader`, ~1 KB) so a hostile server streaming bytes without a newline can't
+exhaust memory. "Connected but silent within the deadline" = Pass-TCP / banner-unknown.
+
+Native **HTTP HEAD**: build the request from the parsed scheme/host/port against the
+single resolved IP; a **fresh, non-reusing transport**, redirects disabled, proxy off,
+and a conservative `MaxResponseHeaderBytes` (remote headers are attacker-controlled and
+potentially large); treat any response (incl. 405 HEAD-not-allowed, 3xx) as "responded".
+
+### Target parser (typed, table-driven, precedence-defined)
+```go
+type Target struct { Host string; IP net.IP; Port int; Scheme string; Proto Proto; PortExplicit bool; IsLiteral bool }
+```
+Two **independent** axes (Codex r2 fix — scheme must not be ignored):
+- **Endpoint port:** explicit `:port` always wins; else scheme default
+  (`https`→443, `http`→80); else bare host → 443.
+- **Protocol of the protocol-rows:** an **explicit scheme selects the protocol**
+  (`https`→TLS+HTTP, `http`→HTTP) regardless of port; only when there is **no scheme**
+  is protocol inferred from the effective port (443/8443→TLS+HTTP, 80→HTTP, 22→SSH
+  banner, 25/587→SMTP banner, else stop at Target TCP). So `https://host:80` → TLS+HTTP
+  on port 80; `http://host:443` → plaintext HTTP on 443; `host:22` → SSH banner.
+
+**Validate:** host = RFC-1123 hostname or IPv4 literal; **reject IPv6 literals**
+(`ip.To4()==nil` → error, IPv6 is out of scope); port 1–65535; strict allowlist regex,
+reject everything else. Nothing user-supplied is ever concatenated into a command string.
+
+### Drill-down job model (one active job at a time, v1)
+Lifecycle: `JobQueued → JobRunning → JobDone | JobFailed | JobCanceled | JobTimedOut`.
+- `exec.CommandContext(ctx, name, args...)` — **arg slice, never a shell string.**
+- **Process group:** `SysProcAttr{Setpgid: true}`; on cancel/timeout kill the whole
+  group (`Kill(-pgid, SIGKILL)`) so descendants (e.g. `mtr-packet`) die too.
+- **Single FIFO, terminal event guaranteed:** output lines and the terminal event travel
+  on **one ordered channel** (not separate paths), so buffered final lines can't arrive
+  after — and be discarded as stale relative to — the terminal message. Sequence: start
+  two reader goroutines (stdout, stderr), `WaitGroup.Wait()` both to EOF, *then*
+  `cmd.Wait()`, *then* enqueue **exactly one** terminal event last. Only **output** lines
+  are droppable under overflow; the **terminal event is never dropped** — it uses a
+  reserved slot / a guaranteed (blocking) send after queued output has drained, so a full
+  queue can never leave a job stuck in `JobRunning`.
+- **Terminal-state classification (centralized, exactly-once, success-wins):**
+  `cmd.Wait() == nil` → **Done** (a process that exited 0 just as its deadline expired is
+  not a timeout). Only when `Wait()` returns an error do we consult `context.Cause(ctx)`
+  (Canceled vs DeadlineExceeded) + `ExitError.ExitCode()` → Failed/Canceled/TimedOut.
+- **Bounded output + non-blocking overflow:** per-stream byte + line caps; use a
+  byte-capped reader (not bare `bufio.Scanner`, whose 64 KB line limit errors on long
+  lines) — truncate over-long lines and mark `…[truncated]`. Readers push into a
+  **bounded non-blocking queue**: once a cap/queue is full the reader **keeps draining
+  and discarding** bytes (incrementing a dropped-bytes counter) so it never blocks on
+  send — a blocked reader would otherwise stall the child and prevent drain/terminal
+  delivery (deadlock). Dropped count is surfaced in the pane. Guards against `ss`,
+  hostile headers, noisy tools.
+- **Message identity:** `ToolOutputMsg{JobID, Generation, Stream, Line}` carries
+  stdout/stderr identity; the Bubble Tea `Update` loop is the **sole owner** of the
+  bounded buffers and splits them into `ToolResult.Stdout/Stderr`. Stale-job messages
+  (JobID/Generation mismatch) are dropped — mirrors the existing `generation` guard.
+- **State-dependent keymap (non-blocking pending-action, never await in `Update`):**
+  `Update` must never block waiting for a terminal event — it *is* the goroutine that
+  consumes it (blocking = deadlock). Instead: a state-changing key pressed while a job
+  runs **calls `cancel()` (non-blocking), stores a `pendingAction`, and returns
+  immediately**; `Update` keeps consuming job output/terminal events; when the job's
+  **terminal event** arrives, the stored `pendingAction` is executed. Actions:
+  - another tool → `pendingAction = startTool(x)`;
+  - `r` (rerun chain) → `pendingAction = rerun`; generation is bumped **only** when that
+    action runs on the terminal event, never while a job is in flight;
+  - `q`/`ctrl+c` → `pendingAction = quit` (`tea.Quit` emitted on the terminal event, so no
+    orphan process is left).
+  While a cancellation is pending, further state-changing keys **replace** the
+  `pendingAction` (last write wins); the cancel is idempotent.
+- Bounded command shapes + per-tool context timeout:
+  - `ping -c 4 -W 2 <host>`
+  - `traceroute -w 2 -q 1 -m 20 <host>`
+  - `mtr --report --report-cycles 5 <host>` (report mode; never curses in our TUI)
+  - `curl` for facts (arg slice): `curl -q -sS --head -o /dev/null --max-redirs 0
+    --noproxy '*' --proto '=https,http' --connect-timeout 3 --max-time 10
+    -w '%{http_code} %{time_total} %{remote_ip} %{ssl_verify_result}\n' <url>`.
+    `LC_ALL=C` is **not** an argv token — set it via `cmd.Env = append(os.Environ(),
+    "LC_ALL=C")`; the displayed `$ command` string shows `LC_ALL=C curl …` (shell-quoted
+    for human display only). `-q` first ignores curlrc; `--write-out` = locale-proof facts.
+  - `dig +time=2 +tries=1 <host>` / `resolvectl query <host>`
+  - `ss -tunp` / `ip route`
+  - `nmap -Pn -p <port> --host-timeout 10s <host>` — **deferred to a later phase**
+- Job pane: exact `$ command`, elapsed timer, live (sanitized) output, then on
+  completion an "Extracted:" facts block above bounded raw output + final status.
+
+### Facts (typed, generation-scoped)
+```go
+type Confidence int // High | Medium | Low
+type Fact struct {
+    Key, Value string
+    Confidence Confidence
+    Source     string    // "dig","curl",...
+    Target     string
+    Generation int       // run generation this fact belongs to
+    JobID      string
+    At         time.Time
+}
+```
+Extraction runs only after the command finishes; facts are replaced **atomically per
+completed job** and discarded if their `Generation` no longer matches — stale reruns
+can't contaminate the current view.
+
+### Terminal-output safety (security)
+All bytes that originate from external tools **or remote servers** (banners, `curl -v`,
+`dig` of attacker-controlled records) are **sanitized before rendering**: strip C0/C1
+control bytes and ANSI/OSC/CSI escape sequences so a malicious banner can't hijack the
+terminal. Bounded *sanitized* text is what we keep; export is also sanitized text.
+
+### Privilege model — unprivileged + hint (never sudo in v1)
+Prefer root-free flags. On EPERM/"permission denied", show stderr + a copyable hint
+("may need root: `sudo mtr ...`"). Never spawn sudo, never prompt for a password,
+no `[S]` re-run in v1.
+
+### UI
+Two-pane: **Chain** (left, selectable) | **Diagnosis** (right, verdict + evidence).
+Contextual bottom toolbox keyed to the selected row. Tool run opens a job pane.
+Scrollable output via `bubbles/viewport`; keep `lipgloss`. Missing tools detected via
+`exec.LookPath` → greyed out with an install hint.
+
+### CLI / exit codes
+`network-doctor` | `<host>` | `<host>:<port>` | `https://<host>` | `--toolbox [<host>]`.
+
+**No argument preserves today's behavior.** Generic DAG (no target path): `Interface up`
+is the only prerequisite, and `Internet TCP` (egress endpoint list) + `DNS lookup`
+(probe host) are **siblings** that both depend solely on Interface — so an egress failure
+never skips DNS, and vice-versa. The IP/source row is taken from the winning egress
+connection's `LocalAddr` (or the UDP-connect fallback on failure); the default route is
+supplementary display, not a hard node. No target-specific rows. A target adds the target path + protocol rows. `--toolbox <host>`
+opens directly in toolbox mode (chain not auto-run), all tools available. `--toolbox`
+**with no host** = local-tools-only mode: target-independent tools (`ip`, `ss`) enabled;
+target-dependent tools (ping/dig/curl/mtr/traceroute) greyed out until a target is given.
+
+**Exit-code table** (drill-down jobs never affect process exit):
+| Situation | Exit |
+|---|---|
+| Chain completed, no `Fail` row (Skips allowed) | 0 |
+| Any `Fail` row | 1 |
+| Quit before the chain finished | 1 |
+| `--toolbox` mode (no chain run) | 0 |
+| Internal error (bad args, validation reject) | 2 |
+
+### File layout (Go, single `main` package)
+- `checks.go` → native probes: DAG scheduler + generation-scoped run state, `ProbeResult`
+  contract (replaces string-only `Result`), multi-A-record resolution + per-address
+  budgeting + IP pinning, hybrid path discovery (TCP `LocalAddr` on success, UDP-connect
+  fallback on failure), banner grabs, protocol-aware builder.
+- `route_linux.go` → keep `defaultRoute()` (now supplementary display only); ARP
+  `gatewayReachable()` retired from the chain (repurpose later as a drill-down or delete).
+- `target.go` (new) → typed parser + validation + precedence table.
+- `jobs.go` (new) → job manager, `runTool`, reader goroutines, process-group kill,
+  terminal-state classification, bounded buffers, messages.
+- `tools.go` (new) → adapters, bounded command shapes, `LookPath`, fact extraction.
+- `sanitize.go` (new) → control/ANSI-escape stripping for display + export.
+- `diagnosis.go` (new) → engine (native state → verdict + evidence).
+- `model.go` → rewrite: two-pane + toolbox + job pane; four-state rows
+  (`Pass/Fail/Skip/NotApplicable`); viewport; state-dependent keymap; generation/JobID guards.
+- `export.go` (new) → markdown report, mode `0600`, timestamped filename (no clobber),
+  header warning it contains local network details. Tool/remote output is **double-safe**:
+  control/ANSI sanitized **and** emitted as a **4-space-indented code block** (every
+  untrusted line indented) rather than a ``` fence — a fence is breakable if the output
+  contains its own closing fence, and a standalone `.md` can't enforce "raw HTML
+  disabled". Indented code blocks have no closing delimiter to inject and render literally,
+  so attacker output can't smuggle Markdown/HTML or remote-image beacons.
+- Tests: keep `route_linux_test`; add table tests for target parsing/validation,
+  diagnosis engine, fact extraction (fixture stdout). **Sanitization tests
+  (security-critical):** table + fuzz cases for split/partial ANSI/OSC/CSI sequences,
+  C0/C1 control bytes, over-long escape sequences, and malformed UTF-8 — assert no
+  control bytes survive to display. **Highest-risk integration tests** via the
+  `os/exec` helper-process pattern, run under `go test -race`: real subprocess
+  cancel/timeout, process-group kill, pipe drain ordering, stale-message drop,
+  byte/line caps + long-line truncation, and overflow without losing the terminal event.
+  **DAG scheduler tests:** sibling independence (egress fails, DNS still runs),
+  dependency skips, generation reset clears run state, per-address time budgeting,
+  IP pinning on first success, and the all-address-failure fallback selection.
+  **Keymap-during-job test:** `r`/new-tool/`q` while a job runs cancels-and-awaits it (no
+  stale-dropped terminal event, no stuck `JobRunning`, no orphan process).
+
+### Phasing
+- **Phase 1** — native DAG scheduler + `ProbeResult` contract + multi-address resolution
+  + hybrid path discovery + diagnosis engine + two-pane UI + exit-code table + target
+  parser. No external tools.
+- **Phase 2** — job manager (process group, drain ordering, bounds, sanitize) +
+  adapters dig, curl, ping + job pane + `-race` integration tests.
+- **Phase 3** — traceroute, mtr, ss, ip; markdown export; `--toolbox` mode.
+- **Later** — nmap; multi-job list; Warn state + mtr route-quality row.
+
+## Key decisions & tradeoffs
+1. **Diagnosis-first, native-only diagnosis.** Verdict computed solely from native
+   probes; tool facts are display-only evidence (no feedback path → no precedence engine).
+2. **Dependency-graph chain, not linear skip.** Independent probes (esp. Internet TCP)
+   run regardless of unrelated failures, so "DNS-only failure" is diagnosable.
+3. **Resolve-all + pin-first + hybrid path discovery.** Retain all A records, try each
+   (per-address budget), pin the first that connects and thread it through the protocol
+   probes; path identity = winning `conn.LocalAddr` on success, UDP-connect fallback on
+   failure. Avoids LB drift, single-dead-IP false failures, and fictitious paths.
+4. **RTT via TCP-connect timing, not ICMP.** No root, no `ping` dep, no home-screen parsing.
+5. **Streaming async jobs, one at a time (v1)**, with process-group kill, drain-before-wait,
+   bounded buffers, and a state-dependent keymap.
+6. **Parse little, sanitize always, keep bounded raw.** Facts best-effort post-completion;
+   all tool/remote bytes sanitized before render to prevent terminal-escape injection.
+7. **Unprivileged + hint, never auto-sudo. Arg-slice exec + strict target validation.**
+
+## Risks / open questions
+- **Flag portability** across distros: `ping -W` units (iputils seconds vs busybox),
+  `traceroute`/`mtr` flag availability. Confirm on Arch; degrade with `LookPath` + hints.
+- **Banner grabs:** servers that stay silent until spoken to — treat "connected but
+  silent within deadline" as Pass-TCP / banner-unknown, not Fail.
+- **UDP-connect path discovery** returns a route even when offline (no packets sent);
+  use it for *path identity*, not as a reachability claim — reachability stays TCP-based.
+- **Fact extraction fragility** across tool versions; raw (sanitized) output stays authoritative.
+
+## Out of scope (v1)
+- nmap; multiple concurrent jobs; jobs list view.
+- Warn (`!`) status and mtr-parsed route-quality row.
+- IPv6 (chain stays IPv4-only). macOS/Windows (Linux-only).
+- Auto-sudo / privilege escalation / in-TUI password prompts.
+- Curses/interactive tool modes embedded in our TUI (report mode only).
+- Structured dashboards that parse every tool into fixed widgets.

--- a/README.md
+++ b/README.md
@@ -1,42 +1,57 @@
 # network-doctor
 
-A terminal UI that diagnoses your network connectivity from the link layer up
-and tells you what to fix when something is broken.
+A terminal UI that diagnoses your network connectivity and tells you **where the
+connection breaks** in plain English — not just a wall of tool output.
 
-It runs five checks in order — each one a prerequisite for the next — so the
-first ✗ you read top-down is the earliest point your connection breaks.
+The home screen runs short, native, rootless probes as a small dependency graph,
+then a diagnosis engine turns their combined state into a one-line verdict. The
+left pane is the probe chain; the right pane is the diagnosis plus details for
+the selected probe.
 
 ```
-Network Doctor
+Network Doctor                Diagnosis
 
-✓ Link — interface wlan0 is up
-✓ IP address — have IPv4 192.168.1.42
-✓ Gateway — default route via 192.168.1.1
-✗ Name resolution — cannot resolve connectivitycheck.gstatic.com: ...
-    → Fix: name resolution failing — check /etc/resolv.conf / DNS
-✗ Internet — request failed: ...
-    → Fix: no internet — check upstream connectivity
+✓ Interface                   github.com:443 is reachable and responding.
+✓ Internet (TCP egress)
+✓ DNS github.com              HTTP github.com
+✓ TCP github.com:443          PASS — HTTP 200 (responded)
+✓ TLS github.com
+✓ HTTP github.com
 
-r: rerun · q: quit
+↑/↓ select · r rerun · q quit
 ```
 
-## Checks
+## How it diagnoses
 
-| # | Check | Passes when | Notes |
-|---|-------|-------------|-------|
-| 1 | **Link** | A non-loopback interface is up and running | cable/Wi-Fi present |
-| 2 | **IP address** | You hold a non-loopback, non-link-local IPv4 | rejects `127/8` and `169.254/16` (no-DHCP) |
-| 3 | **Gateway** | An IPv4 default route exists | read from `/proc/net/route`, lowest metric |
-| 4 | **Name resolution** | The probe host resolves to an IPv4 | system resolution: `/etc/hosts` + resolvers |
-| 5 | **Internet** | `GET /generate_204` returns exactly `204` | a captive portal's `200`/redirect is a Fail |
+Probes form a **dependency graph with two paths**, so an unrelated failure never
+hides a working one:
 
-The probe host is `connectivitycheck.gstatic.com`. Resolution and the internet
-check hit the same host so a single blocked host can't cause a misleading
-result. Every check is IPv4-only and bounded by a 4-second timeout.
+- **Direct-egress path** (independent of DNS): `Interface → Internet (TCP
+  egress)`. Always runs, so "DNS is down but the internet is up" is diagnosable.
+- **Target path** (needs the resolved IP): `Interface → DNS → TCP → protocol
+  rows`.
+
+Each row is one of four states: **✓ Pass**, **✗ Fail**, **⊘ Skip** (a
+prerequisite failed), or **– N/A** (doesn't apply — e.g. DNS on an IP literal).
+
+| Probe | Passes when | Notes |
+|-------|-------------|-------|
+| **Interface** | A non-loopback interface is up and running | |
+| **Internet (TCP egress)** | A TCP connect to `1.1.1.1`/`8.8.8.8:443` succeeds | honestly "direct egress" — proxy-only networks can fail this |
+| **DNS** | The host resolves to an IPv4 (system resolution) | IP-literal targets are N/A; all A records are retained |
+| **TCP** | A TCP connect to the target port succeeds | tries each A record, pins the first that connects |
+| **TLS** | The TLS handshake (SNI + cert verification) succeeds | bad/expired cert, clock skew, or MITM → Fail |
+| **HTTP** | Any HTTP response (incl. 3xx/4xx/5xx) is received | HEAD against the pinned IP, redirects off, proxy off |
+| **SSH/SMTP banner** | TCP connects (banner read best-effort) | bounded read; "connected but silent" still passes |
+
+RTT is measured from the TCP-connect handshake (no ICMP, no root). The source IP
+and interface are read from the winning connection's `LocalAddr`, with a
+UDP-connect fallback (sends no packets) for path identity on failure. Every probe
+is IPv4-only and bounded by a 4-second timeout.
 
 ## Install
 
-Requires Go 1.26+. **Linux only** — the gateway check parses `/proc/net/route`.
+Requires Go 1.26+. **Linux only.**
 
 ```sh
 go install github.com/mplaczek99/network-doctor@latest
@@ -53,44 +68,74 @@ go build -o network-doctor .
 ## Usage
 
 ```sh
-network-doctor              # generic local + internet diagnosis
-network-doctor github.com   # diagnose the path to a specific host
+network-doctor                  # generic local + internet diagnosis
+network-doctor github.com       # diagnose the path to a host (→ TLS + HTTP)
+network-doctor github.com:22    # port selects the protocol rows (→ SSH banner)
+network-doctor https://host:80  # explicit scheme selects the protocol (→ TLS on :80)
 ```
 
-Given a target, it keeps the local-infra checks (link, IP, route, gateway) and
-then probes the path to that host — DNS, TCP 443, TLS handshake, HTTP response,
-and SSH 22 — so the first ✗ tells you exactly where the path to that host breaks:
-
-```
-✓ Gateway reachable — gateway answered (ARP)
-✓ DNS github.com — github.com → 140.82.112.4
-✓ TCP github.com:443 — github.com:443 open
-✓ TLS github.com — TLS handshake OK
-✓ HTTP github.com — HTTP 200
-✗ SSH github.com:22 — github.com:22 unreachable: ...
-    → Fix: SSH to github.com:22 blocked/refused. Try:
-      ssh -T git@github.com
-      ssh -T -p 443 git@ssh.github.com
-```
-
-A scheme and trailing slash in the argument are stripped (`https://github.com/`
-== `github.com`).
+The target parser has two independent axes: the **port** (explicit `:port` >
+scheme default > 443) and the **protocol rows** (an explicit `http`/`https`
+scheme wins; otherwise inferred from the port — `443/8443`→TLS+HTTP, `80`→HTTP,
+`22`→SSH, `25/587`→SMTP). Hosts are validated against a strict allowlist; IPv6
+literals are rejected (IPv4 only).
 
 | Key | Action |
 |-----|--------|
-| `r` | rerun all checks |
+| `↑`/`↓` (`k`/`j`) | select a probe row |
+| `r` | rerun the chain |
+| `e` | export a sanitized markdown report |
 | `q` / `Ctrl-C` | quit |
 
-### Exit code
+## Drill-down tools
 
-- `0` — every check passed.
-- `1` — any check failed, or you quit before all checks finished.
+Each row in the diagnosis is *evidence*; when you want proof, run a real tool as
+a cancellable streaming job (one at a time). The contextual toolbox shows the
+tools available for the current target with their hotkeys — missing binaries are
+greyed out with an install hint. Output is bounded, sanitized (no terminal-escape
+injection from a hostile server), and a few stable facts are extracted on
+completion.
 
-This makes it usable in scripts and health gates:
+| Key | Tool | Command shape |
+|-----|------|---------------|
+| `i` | `ip route` | `ip route` |
+| `s` | `ss` | `ss -tunp` |
+| `p` | `ping` | `ping -c 4 -W 2 <host>` |
+| `d` | `dig` | `dig +time=2 +tries=1 <host>` |
+| `c` | `curl` | `curl -q -sS --head … -w '…' <url>` (locale-proof facts) |
+| `t` | `traceroute` | `traceroute -w 2 -q 1 -m 20 <host>` |
+| `m` | `mtr` | `mtr --report --report-cycles 5 <host>` |
+
+`ip` and `ss` are target-independent; the rest need a host. Tools are run with an
+argument slice (never a shell string), in their own process group (cancel kills
+descendants too), unprivileged — on a permission error you get the command to
+re-run with `sudo`, never an auto-escalation.
+
+`--toolbox [<host>]` opens straight into the toolbox without auto-running the
+chain (press `r` to run it). With no host, only the target-independent tools are
+offered.
+
+### Exit codes
+
+| Situation | Exit |
+|---|---|
+| Chain completed, no failed row (Skips allowed) | `0` |
+| Any failed row | `1` |
+| Quit before the chain finished | `1` |
+| Bad arguments / validation reject | `2` |
 
 ```sh
-network-doctor || echo "network is down"
+network-doctor github.com || echo "path to github is broken"
 ```
+
+## Roadmap
+
+Implemented: native DAG probes + diagnosis engine + two-pane UI (Phase 1),
+cancellable streaming tool jobs with `ping`/`dig`/`curl` (Phase 2), and
+`traceroute`/`mtr`/`ss`/`ip` + markdown export + `--toolbox` mode (Phase 3).
+
+Still to come: `nmap`, multiple concurrent jobs, a `Warn` state, and an
+mtr-parsed route-quality row. See `PLAN.md`.
 
 ## Built with
 
@@ -101,5 +146,7 @@ network-doctor || echo "network is down"
 ## Tests
 
 ```sh
-go test ./...
+go test ./...          # unit + DAG scheduler + parser + diagnosis
+go test -race ./...    # concurrency
+go test -fuzz=FuzzSanitize -fuzztime=10s   # terminal-escape sanitizer
 ```

--- a/checks.go
+++ b/checks.go
@@ -1,278 +1,485 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
-// Status is true when a check passes.
-type Status bool
+// Status is a probe's four-state outcome. Skip = a prerequisite failed (an
+// independent probe is never Skipped for an unrelated sibling's failure).
+// NotApplicable = the probe doesn't apply at all (DNS on an IP literal, a
+// protocol row absent for this port) — not counted as a failure.
+type Status int
 
 const (
-	Fail Status = false
-	Pass Status = true
+	StatusPass Status = iota
+	StatusFail
+	StatusSkip
+	StatusNA
 )
 
-// Result is what a Check reports: an outcome, a human-readable detail, and a
-// remediation hint shown only on failure.
-type Result struct {
-	Status Status
-	Detail string
-	Fix    string
+func (s Status) String() string {
+	switch s {
+	case StatusPass:
+		return "PASS"
+	case StatusFail:
+		return "FAIL"
+	case StatusSkip:
+		return "SKIP"
+	case StatusNA:
+		return "N/A"
+	}
+	return "?"
 }
 
-// Check is one diagnostic. Run must honor ctx (timeout/cancel) and never panic.
-type Check struct {
+// FailClass categorises a failure for the diagnosis engine without parsing
+// display strings.
+type FailClass int
+
+const (
+	FailNone FailClass = iota
+	FailTimeout
+	FailRefused
+	FailNoRoute
+	FailDNS
+	FailTLS
+	FailOther
+)
+
+// Attempt is one connection attempt against a single address.
+type Attempt struct {
+	IP  net.IP
+	Dur time.Duration
+	Err error
+}
+
+// ProbeID is a stable DAG node id.
+type ProbeID string
+
+const (
+	pIface     ProbeID = "iface"
+	pInternet  ProbeID = "internet_tcp"
+	pDNS       ProbeID = "dns"
+	pTargetTCP ProbeID = "target_tcp"
+	pTLS       ProbeID = "tls"
+	pHTTP      ProbeID = "http"
+	pSSH       ProbeID = "ssh_banner"
+	pSMTP      ProbeID = "smtp_banner"
+)
+
+// ProbeResult is the typed contract the diagnosis engine and renderer consume.
+// Detail/Fix are derived human text, never parsed back.
+type ProbeResult struct {
+	ID         ProbeID
+	Status     Status
+	Fail       FailClass
+	Addrs      []net.IP // DNS publishes all A records here
+	SelectedIP net.IP   // Target TCP publishes the pinned IP
+	Source     net.IP
+	Iface      string
+	Attempts   []Attempt
+	RTT        time.Duration
+	Detail     string
+	Fix        string
+}
+
+// Probe is one DAG node. Run receives an immutable snapshot of just its
+// dependency outputs and must honor ctx and never panic.
+type Probe struct {
+	ID   ProbeID
 	Name string
-	Run  func(ctx context.Context) Result
+	Deps []ProbeID
+	Run  func(ctx context.Context, deps map[ProbeID]ProbeResult) ProbeResult
 }
 
-// checkTimeout bounds every individual check. The model wires this into a
-// per-check context.WithTimeout.
-const checkTimeout = 4 * time.Second
+const (
+	// probeTimeout bounds a single probe (the model wraps each in a child ctx).
+	probeTimeout = 4 * time.Second
+	// minBudget floors the per-address dial budget so a many-A-record host
+	// doesn't shrink each attempt to nothing.
+	minBudget = 700 * time.Millisecond
+	// maxAttempts bounds the recorded/attempted addresses per probe.
+	maxAttempts = 16
+)
 
-// probeHost is the single host used by both name-resolution and internet
-// checks, so a blocked unrelated host can't cause a false negative.
+// probeHost is the host used by the generic (no-target) DNS + egress probes.
 const probeHost = "connectivitycheck.gstatic.com"
 
-// httpClient is dedicated to the internet check:
-//   - Timeout bounds the whole request as a backstop to ctx.
-//   - CheckRedirect refuses redirects: a captive portal 30x/200 must not be
-//     mistaken for a real 204.
-//   - Proxy nil: we test host connectivity, not a proxy.
-//   - DialContext forces tcp4 for IPv4-only consistency.
-var httpClient = &http.Client{
-	Timeout: checkTimeout,
-	CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse
-	},
-	Transport: &http.Transport{
-		Proxy: nil,
-		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			var d net.Dialer
-			return d.DialContext(ctx, "tcp4", addr)
-		},
-	},
-}
+// internetEndpoints is the ordered direct-egress endpoint list; first connect
+// wins. Honestly "direct TCP egress" — proxy-only networks can fail this.
+var internetEndpoints = []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("8.8.8.8")}
 
-// httpsPort and sshPort are the target ports probed in target mode.
-const (
-	httpsPort = 443
-	sshPort   = 22
-)
+// buildProbes constructs the DAG for the given target (nil = generic mode).
+func buildProbes(t *Target) []Probe {
+	iface := Probe{ID: pIface, Name: "Interface", Run: ifaceProbe}
+	internet := Probe{ID: pInternet, Name: "Internet (TCP egress)", Deps: []ProbeID{pIface}, Run: internetProbe}
 
-// checks returns the ordered diagnostic chain. Order is the narrative: the
-// first Fail read top-down is the earliest observed symptom (layered bottom-up:
-// link -> IP -> route -> gateway -> DNS -> TCP -> TLS -> HTTP -> SSH).
-//
-// With no target it runs the generic local+internet chain. With a target it
-// keeps the local-infra prefix, then probes the path to that specific host.
-func checks(target string) []Check {
-	if target == "" {
-		return []Check{
-			{Name: "Link", Run: checkLink},
-			{Name: "IP address", Run: checkIP},
-			{Name: "Gateway", Run: checkGateway},
-			{Name: "Name resolution", Run: checkResolve},
-			{Name: "Internet", Run: checkInternet},
-		}
+	if t == nil {
+		// Egress and DNS are siblings: each depends only on the interface, so an
+		// egress failure never hides a DNS failure (or vice-versa).
+		dns := Probe{ID: pDNS, Name: "DNS", Deps: []ProbeID{pIface}, Run: dnsProbe(probeHost, false, nil)}
+		return []Probe{iface, internet, dns}
 	}
-	tcpFix := "port " + strconv.Itoa(httpsPort) + " blocked/refused — firewall or wrong network?"
-	return []Check{
-		{Name: "Link", Run: checkLink},
-		{Name: "IP address", Run: checkIP},
-		{Name: "Default route", Run: checkGateway},
-		{Name: "Gateway reachable", Run: checkGatewayReachable},
-		{Name: "DNS " + target, Run: targetResolve(target)},
-		{Name: "TCP " + target + ":" + strconv.Itoa(httpsPort), Run: targetTCP(target, httpsPort, tcpFix)},
-		{Name: "TLS " + target, Run: targetTLS(target)},
-		{Name: "HTTP " + target, Run: targetHTTP(target)},
-		{Name: "SSH " + target + ":" + strconv.Itoa(sshPort), Run: targetTCP(target, sshPort, sshFix(target))},
+
+	host, port := t.Host, t.Port
+	dns := Probe{ID: pDNS, Name: "DNS " + host, Deps: []ProbeID{pIface}, Run: dnsProbe(host, t.IsLiteral, t.IP)}
+	ttcp := Probe{ID: pTargetTCP, Name: fmt.Sprintf("TCP %s:%d", host, port), Deps: []ProbeID{pDNS}, Run: targetTCPProbe(port)}
+	probes := []Probe{iface, internet, dns, ttcp}
+
+	switch t.Proto {
+	case ProtoTLSHTTP:
+		probes = append(probes,
+			Probe{ID: pTLS, Name: "TLS " + host, Deps: []ProbeID{pTargetTCP}, Run: tlsProbe(host, port)},
+			Probe{ID: pHTTP, Name: "HTTP " + host, Deps: []ProbeID{pTargetTCP}, Run: httpProbe(host, port, "https")},
+		)
+	case ProtoHTTP:
+		probes = append(probes,
+			Probe{ID: pHTTP, Name: "HTTP " + host, Deps: []ProbeID{pTargetTCP}, Run: httpProbe(host, port, "http")},
+		)
+	case ProtoSSH:
+		probes = append(probes, bannerProbe(pSSH, fmt.Sprintf("SSH banner %s:%d", host, port), port))
+	case ProtoSMTP:
+		probes = append(probes, bannerProbe(pSMTP, fmt.Sprintf("SMTP banner %s:%d", host, port), port))
 	}
+	return probes
 }
 
-// normalizeTarget strips a scheme and trailing slash so `netdoc https://github.com/`
-// and `netdoc github.com` behave the same.
-// ponytail: bare host only — doesn't parse out a port or path in the arg, add if needed.
-func normalizeTarget(s string) string {
-	s = strings.TrimSpace(s)
-	s = strings.TrimPrefix(s, "https://")
-	s = strings.TrimPrefix(s, "http://")
-	return strings.TrimSuffix(s, "/")
-}
+// ---- probe implementations ----
 
-// sshFix is the remediation hint shown when SSH to the target is blocked.
-// github.com gets its known ssh-over-443 fallback; other hosts get the generic form.
-func sshFix(host string) string {
-	if host == "github.com" {
-		return "SSH to github.com:22 blocked/refused. Try:\n      ssh -T git@github.com\n      ssh -T -p 443 git@ssh.github.com"
-	}
-	return "SSH to " + host + ":22 blocked/refused — firewall? try over 443 if the host supports it"
-}
-
-// checkLink: at least one non-loopback interface that is up and running.
-func checkLink(ctx context.Context) Result {
+func ifaceProbe(ctx context.Context, _ map[ProbeID]ProbeResult) ProbeResult {
+	r := ProbeResult{ID: pIface}
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		return Result{Fail, "cannot list interfaces: " + err.Error(), "check permissions / network stack"}
+		r.Status, r.Fail = StatusFail, FailOther
+		r.Detail, r.Fix = "cannot list interfaces: "+err.Error(), "check permissions / network stack"
+		return r
 	}
 	for _, ifi := range ifaces {
 		if ifi.Flags&net.FlagLoopback != 0 {
 			continue
 		}
 		if ifi.Flags&net.FlagUp != 0 && ifi.Flags&net.FlagRunning != 0 {
-			return Result{Pass, "interface " + ifi.Name + " is up", ""}
+			r.Status, r.Detail = StatusPass, "interface "+ifi.Name+" is up"
+			return r
 		}
 	}
-	return Result{Fail, "no interface up", "bring up an interface (cable/Wi-Fi) or `ip link set <iface> up`"}
+	r.Status, r.Fail = StatusFail, FailNoRoute
+	r.Detail, r.Fix = "no interface up", "bring up an interface (cable/Wi-Fi) or `ip link set <iface> up`"
+	return r
 }
 
-// checkIP: at least one non-loopback, non-link-local IPv4 address.
-func checkIP(ctx context.Context) Result {
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		return Result{Fail, "cannot list addresses: " + err.Error(), "check network stack"}
-	}
-	for _, a := range addrs {
-		ipnet, ok := a.(*net.IPNet)
-		if !ok {
-			continue
+func internetProbe(ctx context.Context, _ map[ProbeID]ProbeResult) ProbeResult {
+	r := ProbeResult{ID: pInternet}
+	conn, sel, attempts, rtt := dialIPs(ctx, internetEndpoints, 443)
+	r.Attempts, r.RTT = attempts, rtt
+	if conn != nil {
+		defer conn.Close()
+		src, iface := pathIdentity(conn, sel, 443)
+		r.Status, r.SelectedIP, r.Source, r.Iface = StatusPass, sel, src, iface
+		r.Detail = fmt.Sprintf("direct egress via %s in %dms (src %s %s)", sel, rtt.Milliseconds(), src, iface)
+		if gw, found, _ := defaultRoute(); found {
+			r.Detail += "; default route via " + gw
 		}
-		ip4 := ipnet.IP.To4()
-		if ip4 == nil {
-			continue // not IPv4 (rejects IPv6)
+		return r
+	}
+	src, iface := pathIdentity(nil, internetEndpoints[0], 443)
+	r.Status, r.Fail, r.Source, r.Iface = StatusFail, classify(lastErr(attempts)), src, iface
+	r.Detail = "no direct TCP egress to 1.1.1.1/8.8.8.8:443"
+	r.Fix = "no internet egress — proxy-only/filtered network? check upstream"
+	return r
+}
+
+func dnsProbe(host string, literal bool, litIP net.IP) func(context.Context, map[ProbeID]ProbeResult) ProbeResult {
+	return func(ctx context.Context, _ map[ProbeID]ProbeResult) ProbeResult {
+		r := ProbeResult{ID: pDNS}
+		if literal {
+			r.Status, r.Addrs, r.SelectedIP = StatusNA, []net.IP{litIP}, litIP
+			r.Detail = "literal IP " + litIP.String() + " — no DNS needed"
+			return r
 		}
-		if ip4.IsLoopback() || ip4.IsLinkLocalUnicast() {
-			continue // reject 127/8 and 169.254/16
-		}
-		return Result{Pass, "have IPv4 " + ip4.String(), ""}
-	}
-	return Result{Fail, "no usable IPv4 address", "no usable IPv4 (DHCP?) — check DHCP / static config"}
-}
-
-// checkGateway: an IPv4 default route exists. Distinguishes an unreadable route
-// table (internal error) from a readable table with no default route.
-func checkGateway(ctx context.Context) Result {
-	gw, found, err := defaultRoute()
-	if err != nil {
-		return Result{Fail, "cannot read route table: " + err.Error(), "internal: /proc/net/route unreadable"}
-	}
-	if !found {
-		return Result{Fail, "no IPv4 default route", "add a default route / check gateway (DHCP?)"}
-	}
-	return Result{Pass, "default route via " + gw, ""}
-}
-
-// checkResolve: resolve the same host the internet check hits, IPv4-only.
-// Honestly tests system name resolution (/etc/hosts + resolvers), not pure DNS.
-func checkResolve(ctx context.Context) Result {
-	ips, err := net.DefaultResolver.LookupIP(ctx, "ip4", probeHost)
-	if err != nil {
-		return Result{Fail, "cannot resolve " + probeHost + ": " + err.Error(), "name resolution failing — check /etc/resolv.conf / DNS"}
-	}
-	if len(ips) == 0 {
-		return Result{Fail, "no IPv4 address for " + probeHost, "name resolution failing — no A record returned"}
-	}
-	return Result{Pass, probeHost + " resolves to " + ips[0].String(), ""}
-}
-
-// checkInternet: HTTP GET the generate_204 endpoint; require status exactly 204.
-// A captive portal returning 200+body (or a redirect) is correctly a Fail.
-func checkInternet(ctx context.Context) Result {
-	url := "http://" + probeHost + "/generate_204"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return Result{Fail, "cannot build request: " + err.Error(), "internal error"}
-	}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return Result{Fail, "request failed: " + err.Error(), "no internet — check upstream connectivity"}
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusNoContent {
-		return Result{Fail, fmt.Sprintf("unexpected status %d", resp.StatusCode), "no internet / captive portal — open a browser to sign in"}
-	}
-	return Result{Pass, "reached internet (204)", ""}
-}
-
-// checkGatewayReachable: the default gateway has a complete ARP entry — proof
-// we've exchanged L2 frames with it (unprivileged, no ICMP/raw socket needed).
-func checkGatewayReachable(ctx context.Context) Result {
-	ok, err := gatewayReachable()
-	if err != nil {
-		return Result{Fail, "cannot check gateway: " + err.Error(), "internal: route/arp table unreadable"}
-	}
-	if !ok {
-		return Result{Fail, "gateway not answering at L2", "gateway down — check cable/Wi-Fi link or DHCP lease"}
-	}
-	return Result{Pass, "gateway answered (ARP)", ""}
-}
-
-// targetResolve resolves the user-supplied target, IPv4-only (system resolution).
-func targetResolve(host string) func(context.Context) Result {
-	return func(ctx context.Context) Result {
 		ips, err := net.DefaultResolver.LookupIP(ctx, "ip4", host)
 		if err != nil {
-			return Result{Fail, "cannot resolve " + host + ": " + err.Error(), "DNS failing — check /etc/resolv.conf / DNS"}
+			r.Status, r.Fail = StatusFail, FailDNS
+			r.Detail = "cannot resolve " + host + ": " + sanitize(err.Error())
+			r.Fix = "name resolution failing — check /etc/resolv.conf / DNS"
+			return r
 		}
 		if len(ips) == 0 {
-			return Result{Fail, "no IPv4 for " + host, "no A record — check the hostname / DNS"}
+			r.Status, r.Fail = StatusFail, FailDNS
+			r.Detail, r.Fix = "no A record for "+host, "no IPv4 address returned — check the hostname / DNS"
+			return r
 		}
-		return Result{Pass, host + " → " + ips[0].String(), ""}
+		r.Status, r.Addrs = StatusPass, ips
+		r.Detail = host + " → " + joinIPs(ips)
+		return r
 	}
 }
 
-// targetTCP dials host:port over IPv4; an open connection => Pass. Used for both
-// the HTTPS (443) and SSH (22) reachability checks, with a port-specific fix.
-func targetTCP(host string, port int, fix string) func(context.Context) Result {
-	addr := net.JoinHostPort(host, strconv.Itoa(port))
-	return func(ctx context.Context) Result {
+func targetTCPProbe(port int) func(context.Context, map[ProbeID]ProbeResult) ProbeResult {
+	return func(ctx context.Context, deps map[ProbeID]ProbeResult) ProbeResult {
+		r := ProbeResult{ID: pTargetTCP}
+		addrs := deps[pDNS].Addrs
+		if len(addrs) == 0 {
+			r.Status, r.Fail, r.Detail = StatusFail, FailDNS, "no resolved addresses"
+			return r
+		}
+		conn, sel, attempts, rtt := dialIPs(ctx, addrs, port)
+		r.Attempts, r.RTT = attempts, rtt
+		if conn != nil {
+			defer conn.Close()
+			src, iface := pathIdentity(conn, sel, port)
+			r.Status, r.SelectedIP, r.Source, r.Iface = StatusPass, sel, src, iface
+			r.Detail = fmt.Sprintf("connected to %s:%d in %dms (src %s %s)", sel, port, rtt.Milliseconds(), src, iface)
+			return r
+		}
+		// All addresses failed: deterministic fallback path = first address.
+		src, iface := pathIdentity(nil, addrs[0], port)
+		r.Status, r.Fail, r.Source, r.Iface = StatusFail, classify(lastErr(attempts)), src, iface
+		r.Detail = fmt.Sprintf("port %d unreachable on all %d address(es)", port, len(addrs))
+		r.Fix = fmt.Sprintf("port %d blocked/refused — firewall, wrong network, or VPN routing?", port)
+		return r
+	}
+}
+
+func tlsProbe(host string, port int) func(context.Context, map[ProbeID]ProbeResult) ProbeResult {
+	return func(ctx context.Context, deps map[ProbeID]ProbeResult) ProbeResult {
+		r := ProbeResult{ID: pTLS}
+		ip := deps[pTargetTCP].SelectedIP
+		if ip == nil {
+			r.Status, r.Detail = StatusSkip, "no pinned IP from Target TCP"
+			return r
+		}
+		d := tls.Dialer{NetDialer: &net.Dialer{}, Config: &tls.Config{ServerName: host}}
+		conn, err := d.DialContext(ctx, "tcp4", net.JoinHostPort(ip.String(), strconv.Itoa(port)))
+		if err != nil {
+			r.Status, r.Fail = StatusFail, FailTLS
+			r.Detail = "TLS handshake failed: " + sanitize(err.Error())
+			r.Fix = "TLS broken — clock skew, bad/expired cert, or MITM proxy?"
+			return r
+		}
+		conn.Close()
+		r.Status, r.SelectedIP, r.Detail = StatusPass, ip, "TLS handshake OK (SNI "+host+")"
+		return r
+	}
+}
+
+func httpProbe(host string, port int, scheme string) func(context.Context, map[ProbeID]ProbeResult) ProbeResult {
+	return func(ctx context.Context, deps map[ProbeID]ProbeResult) ProbeResult {
+		r := ProbeResult{ID: pHTTP}
+		ip := deps[pTargetTCP].SelectedIP
+		if ip == nil {
+			r.Status, r.Detail = StatusSkip, "no pinned IP from Target TCP"
+			return r
+		}
+		dialAddr := net.JoinHostPort(ip.String(), strconv.Itoa(port))
+		// Fresh, non-reusing transport pinned to the selected IP; redirects and
+		// proxy off; bounded response headers (attacker-controlled).
+		tr := &http.Transport{
+			Proxy: nil,
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				var d net.Dialer
+				return d.DialContext(ctx, "tcp4", dialAddr)
+			},
+			TLSClientConfig:        &tls.Config{ServerName: host},
+			MaxResponseHeaderBytes: 64 << 10,
+			DisableKeepAlives:      true,
+		}
+		client := &http.Client{
+			Transport:     tr,
+			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		}
+		url := scheme + "://" + net.JoinHostPort(host, strconv.Itoa(port))
+		req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+		if err != nil {
+			r.Status, r.Fail, r.Detail = StatusFail, FailOther, "cannot build request: "+err.Error()
+			return r
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			r.Status, r.Fail = StatusFail, classify(err)
+			r.Detail, r.Fix = "no HTTP response: "+sanitize(err.Error()), "HTTP blocked — proxy or firewall?"
+			return r
+		}
+		resp.Body.Close()
+		r.Status, r.SelectedIP = StatusPass, ip
+		r.Detail = fmt.Sprintf("HTTP %d (responded)", resp.StatusCode)
+		return r
+	}
+}
+
+func bannerProbe(id ProbeID, label string, port int) Probe {
+	return Probe{ID: id, Name: label, Deps: []ProbeID{pTargetTCP}, Run: func(ctx context.Context, deps map[ProbeID]ProbeResult) ProbeResult {
+		r := ProbeResult{ID: id}
+		ip := deps[pTargetTCP].SelectedIP
+		if ip == nil {
+			r.Status, r.Detail = StatusSkip, "no pinned IP from Target TCP"
+			return r
+		}
 		var d net.Dialer
-		conn, err := d.DialContext(ctx, "tcp4", addr)
+		conn, err := d.DialContext(ctx, "tcp4", net.JoinHostPort(ip.String(), strconv.Itoa(port)))
 		if err != nil {
-			return Result{Fail, addr + " unreachable: " + err.Error(), fix}
+			r.Status, r.Fail, r.Detail = StatusFail, classify(err), "connect failed: "+sanitize(err.Error())
+			return r
 		}
-		conn.Close()
-		return Result{Pass, addr + " open", ""}
+		defer conn.Close()
+		conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		// Strict byte limit: a hostile server streaming without a newline can't
+		// exhaust memory.
+		br := bufio.NewReader(io.LimitReader(conn, 1024))
+		line, _ := br.ReadString('\n')
+		line = strings.TrimRight(line, "\r\n")
+		r.Status, r.SelectedIP = StatusPass, ip
+		if line == "" {
+			r.Detail = "connected, no banner within deadline"
+		} else {
+			r.Detail = "banner: " + sanitize(line)
+		}
+		return r
+	}}
+}
+
+// ---- shared helpers ----
+
+// dialIPs dials each ip:port in order, giving each address a per-destination
+// budget within ctx's deadline, and returns the first successful conn, the IP
+// that won (pinned for protocol probes), the bounded attempt record, and the
+// winning RTT. ponytail: serial dial; happy-eyeballs parallelism is a later opt.
+func dialIPs(ctx context.Context, ips []net.IP, port int) (net.Conn, net.IP, []Attempt, time.Duration) {
+	var attempts []Attempt
+	n := len(ips)
+	if n == 0 {
+		return nil, nil, attempts, 0
+	}
+	if n > maxAttempts {
+		n = maxAttempts
+	}
+	budget := remaining(ctx) / time.Duration(n)
+	if budget < minBudget {
+		budget = minBudget
+	}
+	var d net.Dialer
+	for i := 0; i < n; i++ {
+		ip := ips[i]
+		addr := net.JoinHostPort(ip.String(), strconv.Itoa(port))
+		actx, cancel := context.WithTimeout(ctx, budget)
+		start := time.Now()
+		conn, err := d.DialContext(actx, "tcp4", addr)
+		dur := time.Since(start)
+		cancel()
+		attempts = append(attempts, Attempt{IP: ip, Dur: dur, Err: err})
+		if err == nil {
+			return conn, ip, attempts, dur
+		}
+		if ctx.Err() != nil {
+			break // overall deadline/cancel reached
+		}
+	}
+	return nil, nil, attempts, 0
+}
+
+// pathIdentity returns the source IP + interface for a destination. On a
+// successful connect it reads the winning LocalAddr (ground truth); otherwise it
+// falls back to a UDP "connect" (sends no packets) for path identity only — not
+// a reachability claim.
+func pathIdentity(conn net.Conn, dstIP net.IP, port int) (net.IP, string) {
+	var src net.IP
+	if conn != nil {
+		if la, ok := conn.LocalAddr().(*net.TCPAddr); ok {
+			src = la.IP
+		}
+	} else if dstIP != nil {
+		if c, err := net.Dial("udp4", net.JoinHostPort(dstIP.String(), strconv.Itoa(port))); err == nil {
+			if la, ok := c.LocalAddr().(*net.UDPAddr); ok {
+				src = la.IP
+			}
+			c.Close()
+		}
+	}
+	if src == nil {
+		return nil, ""
+	}
+	return src, ifaceForIP(src)
+}
+
+// ifaceForIP maps a source IP back to an interface name. LocalAddr gives an IP,
+// not a name, so ambiguity (same IP on >1 iface) and no-match are explicit
+// states, not a guess.
+func ifaceForIP(ip net.IP) string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	name, count := "", 0
+	for _, ifi := range ifaces {
+		addrs, err := ifi.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, a := range addrs {
+			if ipnet, ok := a.(*net.IPNet); ok && ipnet.IP.Equal(ip) {
+				name, count = ifi.Name, count+1
+			}
+		}
+	}
+	switch {
+	case count == 0:
+		return "(unknown iface)"
+	case count > 1:
+		return "(ambiguous)"
+	default:
+		return name
 	}
 }
 
-// targetTLS does a full TLS handshake to host:443 with SNI and cert verification
-// (the default tls.Config). A bad/expired cert or MITM proxy is correctly a Fail.
-func targetTLS(host string) func(context.Context) Result {
-	addr := net.JoinHostPort(host, strconv.Itoa(httpsPort))
-	return func(ctx context.Context) Result {
-		d := tls.Dialer{Config: &tls.Config{ServerName: host}}
-		conn, err := d.DialContext(ctx, "tcp4", addr)
-		if err != nil {
-			return Result{Fail, "TLS handshake failed: " + err.Error(), "TLS broken — clock skew, bad cert, or MITM proxy?"}
-		}
-		conn.Close()
-		return Result{Pass, "TLS handshake OK", ""}
+func classify(err error) FailClass {
+	switch {
+	case err == nil:
+		return FailNone
+	case errors.Is(err, context.DeadlineExceeded):
+		return FailTimeout
+	case errors.Is(err, syscall.ECONNREFUSED):
+		return FailRefused
+	case errors.Is(err, syscall.ENETUNREACH), errors.Is(err, syscall.EHOSTUNREACH), errors.Is(err, syscall.ENETDOWN):
+		return FailNoRoute
+	default:
+		return FailOther
 	}
 }
 
-// targetHTTP GETs https://host; any HTTP response (incl. 3xx/4xx/5xx) => Pass.
-// Reuses httpClient, whose CheckRedirect returns the redirect response rather
-// than following it, so a 30x still counts as "a response was received".
-func targetHTTP(host string) func(context.Context) Result {
-	url := "https://" + host
-	return func(ctx context.Context) Result {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-		if err != nil {
-			return Result{Fail, "cannot build request: " + err.Error(), "internal error"}
+func lastErr(attempts []Attempt) error {
+	for i := len(attempts) - 1; i >= 0; i-- {
+		if attempts[i].Err != nil {
+			return attempts[i].Err
 		}
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			return Result{Fail, "no HTTP response: " + err.Error(), "HTTP blocked — proxy or firewall?"}
-		}
-		defer resp.Body.Close()
-		return Result{Pass, fmt.Sprintf("HTTP %d", resp.StatusCode), ""}
 	}
+	return nil
+}
+
+func joinIPs(ips []net.IP) string {
+	parts := make([]string, len(ips))
+	for i, ip := range ips {
+		parts[i] = ip.String()
+	}
+	return strings.Join(parts, ", ")
+}
+
+// remaining returns the time left on ctx's deadline, or probeTimeout if none.
+func remaining(ctx context.Context) time.Duration {
+	if dl, ok := ctx.Deadline(); ok {
+		if d := time.Until(dl); d > 0 {
+			return d
+		}
+		return 0
+	}
+	return probeTimeout
 }

--- a/checks_test.go
+++ b/checks_test.go
@@ -1,54 +1,94 @@
 package main
 
 import (
-	"strings"
+	"context"
+	"net"
 	"testing"
+	"time"
 )
 
-func TestNormalizeTarget(t *testing.T) {
-	tests := map[string]string{
-		"github.com":          "github.com",
-		"https://github.com":  "github.com",
-		"http://github.com/":  "github.com",
-		"  github.com/ ":      "github.com",
-		"https://github.com/": "github.com",
+func mustTarget(t *testing.T, s string) *Target {
+	t.Helper()
+	tg, err := parseTarget(s)
+	if err != nil {
+		t.Fatalf("parseTarget(%q): %v", s, err)
 	}
-	for in, want := range tests {
-		if got := normalizeTarget(in); got != want {
-			t.Errorf("normalizeTarget(%q) = %q, want %q", in, got, want)
-		}
+	return tg
+}
+
+// Generic mode: egress and DNS are siblings — an egress failure must NOT skip
+// DNS (the "DNS-down-but-internet-up" case stays diagnosable).
+func TestSiblingIndependence(t *testing.T) {
+	m := newModel(nil)
+	m.results[pIface] = ProbeResult{ID: pIface, Status: StatusPass}
+	m.started[pIface] = true
+	cmds := m.scheduleStep()
+	if len(cmds) != 2 {
+		t.Fatalf("want 2 dispatched (internet, dns), got %d", len(cmds))
+	}
+	if !m.started[pInternet] || !m.started[pDNS] {
+		t.Fatal("internet+dns should both be dispatched")
+	}
+	if _, ok := m.results[pDNS]; ok {
+		t.Error("dns must be dispatched, not skipped by an egress failure")
 	}
 }
 
-// No target -> the generic local+internet chain. A target -> the local-infra
-// prefix plus per-host probes naming that host.
-func TestChecksTargetChain(t *testing.T) {
-	if got := len(checks("")); got != 5 {
-		t.Fatalf("no-target chain len = %d, want 5", got)
+// A failed dependency skips its dependents, and the skip propagates downstream.
+func TestSkipPropagation(t *testing.T) {
+	m := newModel(mustTarget(t, "github.com"))
+	m.results[pIface] = ProbeResult{Status: StatusPass}
+	m.results[pInternet] = ProbeResult{Status: StatusPass}
+	m.results[pDNS] = ProbeResult{Status: StatusFail}
+	m.started[pIface], m.started[pInternet], m.started[pDNS] = true, true, true
+	m.scheduleStep()
+	if m.results[pTargetTCP].Status != StatusSkip {
+		t.Fatalf("target_tcp = %v, want Skip", m.results[pTargetTCP].Status)
 	}
-
-	cs := checks("github.com")
-	if len(cs) != 9 {
-		t.Fatalf("target chain len = %d, want 9", len(cs))
+	if m.results[pTLS].Status != StatusSkip {
+		t.Errorf("tls = %v, want Skip (propagated)", m.results[pTLS].Status)
 	}
-	names := make([]string, len(cs))
-	for i, c := range cs {
-		names[i] = c.Name
-	}
-	joined := strings.Join(names, "\n")
-	for _, want := range []string{"DNS github.com", "TCP github.com:443", "TLS github.com", "HTTP github.com", "SSH github.com:22"} {
-		if !strings.Contains(joined, want) {
-			t.Errorf("target chain missing %q; got:\n%s", want, joined)
-		}
+	if m.results[pHTTP].Status != StatusSkip {
+		t.Errorf("http = %v, want Skip (propagated)", m.results[pHTTP].Status)
 	}
 }
 
-// github.com gets the ssh-over-443 fallback; other hosts get the generic hint.
-func TestSSHFix(t *testing.T) {
-	if !strings.Contains(sshFix("github.com"), "ssh.github.com") {
-		t.Error("github sshFix should mention the ssh.github.com:443 fallback")
+// NotApplicable (IP-literal DNS) still produced output, so it must NOT skip
+// Target TCP — satisfaction is about output, not row status.
+func TestNADoesNotBlock(t *testing.T) {
+	m := newModel(mustTarget(t, "1.1.1.1"))
+	m.results[pIface] = ProbeResult{Status: StatusPass}
+	m.results[pInternet] = ProbeResult{Status: StatusPass}
+	m.results[pDNS] = ProbeResult{Status: StatusNA, Addrs: []net.IP{net.ParseIP("1.1.1.1")}}
+	m.started[pIface], m.started[pInternet], m.started[pDNS] = true, true, true
+	m.scheduleStep()
+	if _, ok := m.results[pTargetTCP]; ok {
+		t.Fatal("an NA dependency must not skip target_tcp")
 	}
-	if strings.Contains(sshFix("example.com"), "ssh.github.com") {
-		t.Error("generic sshFix must not hardcode github")
+	if !m.started[pTargetTCP] {
+		t.Fatal("target_tcp should be dispatched after an NA dependency")
+	}
+}
+
+func TestBuildProbesShape(t *testing.T) {
+	if got := len(buildProbes(nil)); got != 3 {
+		t.Errorf("generic probes = %d, want 3", got)
+	}
+	if got := len(buildProbes(mustTarget(t, "github.com"))); got != 6 {
+		t.Errorf("https target probes = %d, want 6", got)
+	}
+	if got := len(buildProbes(mustTarget(t, "host:22"))); got != 5 {
+		t.Errorf("ssh target probes = %d, want 5", got)
+	}
+}
+
+func TestRemaining(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if d := remaining(ctx); d <= 0 || d > 2*time.Second {
+		t.Errorf("remaining = %v, want (0,2s]", d)
+	}
+	if d := remaining(context.Background()); d != probeTimeout {
+		t.Errorf("remaining(no deadline) = %v, want %v", d, probeTimeout)
 	}
 }

--- a/diagnosis.go
+++ b/diagnosis.go
@@ -1,0 +1,59 @@
+package main
+
+import "fmt"
+
+// diagnose computes the plain-English verdict from current-generation native
+// probe state only (tool facts never feed in). First-fail ordering + combination
+// rules. Returns "Running diagnostics…" until every probe in order has a result.
+func diagnose(t *Target, order []ProbeID, res map[ProbeID]ProbeResult) string {
+	for _, id := range order {
+		if _, ok := res[id]; !ok {
+			return "Running diagnostics…"
+		}
+	}
+	pass := func(id ProbeID) bool { return res[id].Status == StatusPass }
+	fail := func(id ProbeID) bool { return res[id].Status == StatusFail }
+	has := func(id ProbeID) bool { _, ok := res[id]; return ok }
+
+	if fail(pIface) {
+		return "No usable network interface — the link is down."
+	}
+
+	if t == nil {
+		ip, dn := pass(pInternet), pass(pDNS)
+		switch {
+		case ip && dn:
+			return "Online — direct TCP egress and DNS both work."
+		case ip && !dn:
+			return "Internet egress works but DNS resolution is failing."
+		case !ip && dn:
+			return "DNS resolves but there's no direct TCP egress (proxy-only or filtered network?)."
+		default:
+			return "Offline — neither direct egress nor DNS is working."
+		}
+	}
+
+	host := t.Host
+	hp := fmt.Sprintf("%s:%d", host, t.Port)
+	switch {
+	case fail(pDNS):
+		v := "Cannot resolve " + host + " — DNS failure."
+		if pass(pInternet) {
+			v += " (The general internet is reachable.)"
+		}
+		return v
+	case fail(pTargetTCP):
+		if pass(pInternet) {
+			return hp + " is unreachable though DNS and the general internet work — remote port closed, firewall, or VPN routing."
+		}
+		return host + " resolves but neither it nor the general internet is reachable — local egress problem."
+	case has(pTLS) && fail(pTLS):
+		return "TCP reaches " + hp + " but the TLS handshake fails — bad/expired cert, clock skew, or MITM proxy."
+	case has(pHTTP) && fail(pHTTP):
+		return "TLS is fine but no HTTP response from " + hp + " — application-layer or proxy block."
+	case (has(pSSH) && fail(pSSH)) || (has(pSMTP) && fail(pSMTP)):
+		return hp + " accepts TCP but the service banner check failed."
+	default:
+		return hp + " is reachable and responding."
+	}
+}

--- a/diagnosis_test.go
+++ b/diagnosis_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDiagnoseGeneric(t *testing.T) {
+	order := []ProbeID{pIface, pInternet, pDNS}
+	cases := []struct {
+		name          string
+		internet, dns Status
+		want          string
+	}{
+		{"online", StatusPass, StatusPass, "Online"},
+		{"dns down", StatusPass, StatusFail, "DNS resolution is failing"},
+		{"no egress", StatusFail, StatusPass, "no direct TCP egress"},
+		{"offline", StatusFail, StatusFail, "Offline"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			res := map[ProbeID]ProbeResult{
+				pIface:    {Status: StatusPass},
+				pInternet: {Status: c.internet},
+				pDNS:      {Status: c.dns},
+			}
+			if v := diagnose(nil, order, res); !strings.Contains(v, c.want) {
+				t.Errorf("got %q, want substring %q", v, c.want)
+			}
+		})
+	}
+}
+
+func TestDiagnoseIncomplete(t *testing.T) {
+	order := []ProbeID{pIface, pInternet, pDNS}
+	res := map[ProbeID]ProbeResult{pIface: {Status: StatusPass}}
+	if v := diagnose(nil, order, res); !strings.Contains(v, "Running") {
+		t.Errorf("incomplete should report running, got %q", v)
+	}
+}
+
+func TestDiagnoseTarget(t *testing.T) {
+	tg := mustTarget(t, "github.com")
+	order := []ProbeID{pIface, pInternet, pDNS, pTargetTCP, pTLS, pHTTP}
+
+	// DNS + internet OK, Target TCP fails → remote port/firewall verdict.
+	res := map[ProbeID]ProbeResult{
+		pIface: {Status: StatusPass}, pInternet: {Status: StatusPass},
+		pDNS: {Status: StatusPass}, pTargetTCP: {Status: StatusFail},
+		pTLS: {Status: StatusSkip}, pHTTP: {Status: StatusSkip},
+	}
+	if v := diagnose(tg, order, res); !strings.Contains(v, "unreachable") {
+		t.Errorf("got %q, want 'unreachable'", v)
+	}
+
+	// Everything passes → reachable.
+	for _, id := range order {
+		res[id] = ProbeResult{Status: StatusPass}
+	}
+	if v := diagnose(tg, order, res); !strings.Contains(v, "reachable and responding") {
+		t.Errorf("got %q, want success verdict", v)
+	}
+}

--- a/export.go
+++ b/export.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// exportReport writes a sanitized markdown report of the current state to a
+// timestamped, no-clobber file with mode 0600. Tool/remote output is
+// double-safe: control/ANSI sanitized AND emitted as a 4-space-indented code
+// block (no closing fence to inject, so attacker output can't smuggle
+// Markdown/HTML or remote-image beacons). Returns the path written.
+func exportReport(m model) (string, error) {
+	var b strings.Builder
+	b.WriteString("# network-doctor report\n\n")
+	b.WriteString("_Generated " + time.Now().Format(time.RFC3339) + ". Contains local network details — handle with care._\n\n")
+
+	tgt := "generic (no target)"
+	if m.target != nil {
+		tgt = fmt.Sprintf("%s:%d", m.target.Host, m.target.Port)
+	}
+	b.WriteString("Target: " + sanitize(tgt) + "\n\n")
+	b.WriteString("## Diagnosis\n\n" + sanitize(diagnose(m.target, m.order, m.results)) + "\n\n")
+
+	b.WriteString("## Probes\n\n")
+	for _, id := range m.order {
+		name := sanitize(m.byID[id].Name)
+		r, ok := m.results[id]
+		if !ok {
+			b.WriteString("- [ ] " + name + " — not run\n")
+			continue
+		}
+		b.WriteString(fmt.Sprintf("- %s **%s** — %s\n", statusMark(r.Status), name, sanitize(r.Detail)))
+		if r.Status == StatusFail && r.Fix != "" {
+			b.WriteString("  - fix: " + sanitize(r.Fix) + "\n")
+		}
+	}
+
+	if m.jobStatus != JobQueued || len(m.jobOut) > 0 {
+		b.WriteString("\n## Last tool: " + sanitize(m.jobName) + " (" + m.jobStatus.String() + ")\n\n")
+		b.WriteString(indentBlock("$ " + m.jobDisplay))
+		b.WriteString(indentBlock(strings.Join(m.jobOut, "\n")))
+		if len(m.jobErr) > 0 {
+			b.WriteString(indentBlock(strings.Join(m.jobErr, "\n")))
+		}
+		if len(m.facts) > 0 {
+			b.WriteString("Extracted:\n\n")
+			for _, f := range m.facts {
+				b.WriteString("- " + sanitize(f.Key) + ": " + sanitize(f.Value) + "\n")
+			}
+		}
+	}
+
+	path := uniquePath()
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// indentBlock renders untrusted text as a 4-space-indented code block, every
+// line sanitized — no fence delimiter exists for the output to break out of.
+func indentBlock(s string) string {
+	if s == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, ln := range strings.Split(s, "\n") {
+		b.WriteString("    " + sanitize(ln) + "\n")
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func statusMark(s Status) string {
+	switch s {
+	case StatusPass:
+		return "✓"
+	case StatusFail:
+		return "✗"
+	case StatusSkip:
+		return "⊘"
+	case StatusNA:
+		return "–"
+	}
+	return "?"
+}
+
+// uniquePath returns a timestamped report filename that doesn't already exist.
+func uniquePath() string {
+	base := "network-doctor-" + time.Now().Format("20060102-150405")
+	path := base + ".md"
+	for i := 1; ; i++ {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return path
+		}
+		path = fmt.Sprintf("%s-%d.md", base, i)
+	}
+}

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Export must strip escapes and never leave an un-indented ``` fence that
+// attacker-controlled output could use to break out into Markdown/HTML.
+func TestExportSanitizesAndIndents(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	m := newModel(mustTarget(t, "github.com"))
+	m.results[pIface] = ProbeResult{Status: StatusFail, Detail: "evil\x1b[31m```\n# heading\n<script>", Fix: "do x"}
+	m.jobName, m.jobStatus = "ping", JobDone
+	m.jobOut = []string{"```injected fence", "\x1b]0;title\x07normal"}
+
+	path, err := exportReport(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %v, want 0600", info.Mode().Perm())
+	}
+	data, _ := os.ReadFile(path)
+	s := string(data)
+	if strings.ContainsRune(s, 0x1b) {
+		t.Error("ESC survived in export")
+	}
+	for _, ln := range strings.Split(s, "\n") {
+		if strings.HasPrefix(ln, "```") {
+			t.Errorf("un-indented fence in export: %q", ln)
+		}
+	}
+}
+
+func TestExportNoClobber(t *testing.T) {
+	t.Chdir(t.TempDir())
+	m := newModel(nil)
+	p1, err := exportReport(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p2, err := exportReport(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p1 == p2 {
+		t.Errorf("export reused path %q — must not clobber", p1)
+	}
+}

--- a/jobs.go
+++ b/jobs.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// JobStatus is a drill-down job's lifecycle terminal state (plus the two
+// pre-terminal states for display).
+type JobStatus int
+
+const (
+	JobQueued JobStatus = iota
+	JobRunning
+	JobDone
+	JobFailed
+	JobCanceled
+	JobTimedOut
+)
+
+func (s JobStatus) String() string {
+	switch s {
+	case JobQueued:
+		return "queued"
+	case JobRunning:
+		return "running"
+	case JobDone:
+		return "done"
+	case JobFailed:
+		return "failed"
+	case JobCanceled:
+		return "canceled"
+	case JobTimedOut:
+		return "timed out"
+	}
+	return "?"
+}
+
+// Stream identifies which pipe an output line came from.
+type Stream int
+
+const (
+	StreamStdout Stream = iota
+	StreamStderr
+)
+
+// ToolOutputMsg is one sanitized output line. JobID+Generation identity lets
+// Update drop stale-job messages.
+type ToolOutputMsg struct {
+	JobID      string
+	Generation int
+	Stream     Stream
+	Line       string
+}
+
+// ToolDoneMsg is the single guaranteed terminal event for a job. It travels on
+// the same channel as output (single FIFO) so buffered final lines can't arrive
+// after it.
+type ToolDoneMsg struct {
+	JobID      string
+	Generation int
+	Status     JobStatus
+	Err        error
+	Dropped    int64 // output lines dropped under overflow
+}
+
+const (
+	toolTimeout  = 12 * time.Second
+	chanBuf      = 256
+	maxLineBytes = 4096
+)
+
+// job is a running external command. The channel carries ToolOutputMsg lines and
+// then exactly one ToolDoneMsg, last.
+type job struct {
+	id     string
+	gen    int
+	cmd    *exec.Cmd
+	ch     chan tea.Msg
+	cancel context.CancelFunc
+}
+
+// startTool launches name+args as a process-group leader, streaming sanitized
+// output lines and a guaranteed terminal event on job.ch. env nil = inherit.
+// Returns the job and the first wait command to feed into Bubble Tea.
+func startTool(parent context.Context, gen int, id, name string, args, env []string) (*job, tea.Cmd, error) {
+	ctx, cancel := context.WithTimeout(parent, toolTimeout)
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = env
+	// Own process group so we can kill descendants (e.g. mtr-packet).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error { return killGroup(cmd) }
+	cmd.WaitDelay = 2 * time.Second // don't hang on Wait if a child holds the pipe
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, nil, err
+	}
+
+	j := &job{id: id, gen: gen, cmd: cmd, ch: make(chan tea.Msg, chanBuf), cancel: cancel}
+	var dropped int64
+
+	go func() {
+		defer cancel()
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); streamReader(stdout, StreamStdout, id, gen, j.ch, &dropped) }()
+		go func() { defer wg.Done(); streamReader(stderr, StreamStderr, id, gen, j.ch, &dropped) }()
+		wg.Wait() // drain both pipes to EOF before Wait (no drain/wait race)
+		werr := cmd.Wait()
+		// Guaranteed (blocking) terminal send, last — never dropped.
+		j.ch <- ToolDoneMsg{
+			JobID:      id,
+			Generation: gen,
+			Status:     classifyJob(ctx, werr),
+			Err:        werr,
+			Dropped:    atomic.LoadInt64(&dropped),
+		}
+	}()
+
+	return j, waitForMsg(j.ch), nil
+}
+
+// waitForMsg reads the next job message. Update re-issues it after each
+// ToolOutputMsg and stops after the ToolDoneMsg.
+func waitForMsg(ch <-chan tea.Msg) tea.Cmd {
+	return func() tea.Msg { return <-ch }
+}
+
+// streamReader reads capped, sanitized lines and pushes them non-blocking: it
+// always consumes the bytes (so the child never stalls) and only drops the
+// *message* when the channel is full, so the terminal event can still be
+// delivered (no deadlock).
+func streamReader(r io.Reader, stream Stream, id string, gen int, ch chan<- tea.Msg, dropped *int64) {
+	br := bufio.NewReader(r)
+	for {
+		line, err := readCappedLine(br)
+		if line != "" {
+			select {
+			case ch <- ToolOutputMsg{JobID: id, Generation: gen, Stream: stream, Line: sanitize(line)}:
+			default:
+				atomic.AddInt64(dropped, 1)
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// readCappedLine reads one line up to maxLineBytes; a longer line is truncated
+// (marked) and the rest consumed, so a newline-less flood can't exhaust memory.
+func readCappedLine(br *bufio.Reader) (string, error) {
+	var b []byte
+	for {
+		c, err := br.ReadByte()
+		if err != nil {
+			return string(b), err
+		}
+		if c == '\n' {
+			return string(b), nil
+		}
+		switch {
+		case len(b) < maxLineBytes:
+			b = append(b, c)
+		case len(b) == maxLineBytes:
+			b = append(b, "…[truncated]"...)
+		} // else discard until newline
+	}
+}
+
+// classifyJob is centralized, success-wins: a process that exited 0 just as its
+// deadline expired is Done, not TimedOut. Only on a Wait error do we consult the
+// context cause.
+func classifyJob(ctx context.Context, werr error) JobStatus {
+	if werr == nil {
+		return JobDone
+	}
+	switch context.Cause(ctx) {
+	case context.Canceled:
+		return JobCanceled
+	case context.DeadlineExceeded:
+		return JobTimedOut
+	default:
+		return JobFailed
+	}
+}
+
+// killGroup SIGKILLs the whole process group so descendants die too.
+func killGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	if pgid, err := syscall.Getpgid(cmd.Process.Pid); err == nil {
+		return syscall.Kill(-pgid, syscall.SIGKILL)
+	}
+	return cmd.Process.Kill()
+}

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// TestHelperProcess is re-executed as the child process for the job integration
+// tests; it is inert in a normal run.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_HELPER") != "1" {
+		return
+	}
+	switch os.Getenv("GO_HELPER_MODE") {
+	case "lines":
+		n, _ := strconv.Atoi(os.Getenv("GO_HELPER_N"))
+		for i := 0; i < n; i++ {
+			fmt.Printf("line %d\n", i)
+		}
+	case "sleep":
+		time.Sleep(30 * time.Second)
+	case "longline":
+		fmt.Print(strings.Repeat("A", maxLineBytes*2) + "\n")
+	case "flood":
+		for i := 0; i < 20000; i++ {
+			fmt.Printf("flood %d\n", i)
+		}
+	}
+	os.Exit(0)
+}
+
+func startHelper(t *testing.T, parent context.Context, mode string, extra ...string) *job {
+	t.Helper()
+	env := append(os.Environ(), "GO_HELPER=1", "GO_HELPER_MODE="+mode)
+	env = append(env, extra...)
+	j, _, err := startTool(parent, 0, "test-"+mode, os.Args[0], []string{"-test.run=TestHelperProcess"}, env)
+	if err != nil {
+		t.Fatalf("startTool: %v", err)
+	}
+	return j
+}
+
+func drain(t *testing.T, ch chan tea.Msg) ([]string, ToolDoneMsg) {
+	t.Helper()
+	var out []string
+	timeout := time.After(20 * time.Second)
+	for {
+		select {
+		case m := <-ch:
+			switch v := m.(type) {
+			case ToolOutputMsg:
+				out = append(out, v.Line)
+			case ToolDoneMsg:
+				return out, v
+			}
+		case <-timeout:
+			t.Fatal("drain timed out — terminal event never arrived")
+			return out, ToolDoneMsg{}
+		}
+	}
+}
+
+func TestJobStreamsAndCompletes(t *testing.T) {
+	j := startHelper(t, context.Background(), "lines", "GO_HELPER_N=3")
+	out, done := drain(t, j.ch)
+	if len(out) != 3 {
+		t.Fatalf("got %d lines, want 3: %q", len(out), out)
+	}
+	if done.Status != JobDone {
+		t.Errorf("status = %v, want JobDone", done.Status)
+	}
+}
+
+func TestJobCancel(t *testing.T) {
+	j := startHelper(t, context.Background(), "sleep")
+	time.Sleep(50 * time.Millisecond)
+	j.cancel()
+	_, done := drain(t, j.ch)
+	if done.Status != JobCanceled {
+		t.Errorf("status = %v, want JobCanceled", done.Status)
+	}
+}
+
+func TestJobTimeout(t *testing.T) {
+	// A short parent deadline makes the job's context time out well before the
+	// 12s tool timeout; the cause propagates → JobTimedOut.
+	parent, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+	j := startHelper(t, parent, "sleep")
+	_, done := drain(t, j.ch)
+	if done.Status != JobTimedOut {
+		t.Errorf("status = %v, want JobTimedOut", done.Status)
+	}
+}
+
+func TestJobLongLineTruncated(t *testing.T) {
+	j := startHelper(t, context.Background(), "longline")
+	out, done := drain(t, j.ch)
+	if done.Status != JobDone {
+		t.Fatalf("status = %v, want JobDone", done.Status)
+	}
+	if len(out) != 1 {
+		t.Fatalf("got %d lines, want 1", len(out))
+	}
+	if !strings.Contains(out[0], "…[truncated]") {
+		t.Error("over-long line should be marked truncated")
+	}
+	if len(out[0]) > maxLineBytes+64 {
+		t.Errorf("truncated line len = %d, want ~%d", len(out[0]), maxLineBytes)
+	}
+}
+
+// Overflow must drop output lines but still deliver the terminal event.
+func TestJobOverflowKeepsTerminal(t *testing.T) {
+	j := startHelper(t, context.Background(), "flood")
+	time.Sleep(200 * time.Millisecond) // let the reader fill+drop before we read
+	out, done := drain(t, j.ch)
+	if done.Status != JobDone {
+		t.Fatalf("status = %v, want JobDone (terminal must survive overflow)", done.Status)
+	}
+	if len(out) >= 20000 {
+		t.Errorf("expected some lines dropped, got all %d", len(out))
+	}
+	if done.Dropped == 0 {
+		t.Error("expected a non-zero dropped count under overflow")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -8,11 +8,29 @@ import (
 )
 
 func main() {
-	target := ""
-	if len(os.Args) > 1 {
-		target = normalizeTarget(os.Args[1])
+	toolbox := false
+	arg := ""
+	for _, a := range os.Args[1:] {
+		if a == "--toolbox" {
+			toolbox = true
+			continue
+		}
+		arg = a // last non-flag wins
 	}
-	p := tea.NewProgram(newModel(checks(target)))
+
+	var t *Target
+	if arg != "" {
+		parsed, err := parseTarget(arg)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "network-doctor:", err)
+			os.Exit(2) // bad args / validation reject
+		}
+		t = parsed
+	}
+
+	m := newModel(t)
+	m.toolbox = toolbox
+	p := tea.NewProgram(m, tea.WithAltScreen())
 	final, err := p.Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "network-doctor:", err)
@@ -21,16 +39,22 @@ func main() {
 	os.Exit(exitCode(final))
 }
 
-// exitCode derives the process exit status from the final model returned by
-// Run (Bubble Tea's value-update means the original model var is stale).
-// Nonzero if any check failed or any check is still pending (early quit).
+// exitCode derives the process status from the final model: 0 in toolbox mode
+// when the chain never ran; 1 if any probe Failed or the chain didn't finish
+// (early quit); else 0. Skip/NotApplicable are not failures.
 func exitCode(final tea.Model) int {
 	m, ok := final.(model)
 	if !ok {
 		return 1
 	}
-	for _, row := range m.rows {
-		if row.result == nil || !row.result.Status {
+	if m.toolbox && !m.chainRan() {
+		return 0 // toolbox mode, no chain run
+	}
+	if len(m.results) < len(m.probes) {
+		return 1 // quit before the chain finished
+	}
+	for _, id := range m.order {
+		if m.results[id].Status == StatusFail {
 			return 1
 		}
 	}

--- a/model.go
+++ b/model.go
@@ -2,142 +2,194 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
 
-// startCheckMsg asks the model to begin check idx. gen guards against stale
-// reruns: a startCheckMsg whose gen no longer matches the model is ignored.
-type startCheckMsg struct {
-	idx int
+// scheduleMsg asks Update to dispatch any newly-runnable probes for generation
+// gen. A stale gen is ignored.
+type scheduleMsg struct{ gen int }
+
+// probeDoneMsg carries a finished probe's result. Accepted only when gen matches.
+type probeDoneMsg struct {
+	id  ProbeID
 	gen int
+	res ProbeResult
 }
 
-// checkDoneMsg carries a finished check's result back to Update. It is accepted
-// only when running && gen matches && idx is the in-flight check.
-type checkDoneMsg struct {
-	idx int
-	gen int
-	res Result
+// pendingAction is a state change deferred until the active job's terminal event
+// arrives, so Update never blocks waiting on it (that would deadlock — Update is
+// the goroutine that consumes the event).
+type pendingKind int
+
+const (
+	pendNone pendingKind = iota
+	pendQuit
+	pendRerun
+	pendTool
+)
+
+type pendingAction struct {
+	kind pendingKind
+	tool Tool
 }
 
-// checkRow pairs a check with its result (nil result = pending).
-type checkRow struct {
-	check  Check
-	result *Result
-}
+const (
+	maxJobLines  = 500
+	jobTailLines = 14
+)
 
 type model struct {
-	rows     []checkRow
-	inFlight int
+	target *Target
+	probes []Probe
+	order  []ProbeID
+	byID   map[ProbeID]Probe
+
+	// results + started are owned exclusively by Update; probe goroutines get an
+	// immutable snapshot, never the live map.
+	results map[ProbeID]ProbeResult
+	started map[ProbeID]bool
+
+	selected int
 	spinner  spinner.Model
 
 	generation int
-	running    bool
-
-	// Active check's context lifecycle. Owned exclusively by Update — no
-	// tea.Cmd ever writes these. cancel is nil when no check is in flight.
+	// Generation context; cancel kills all in-flight probes and the active job on
+	// rerun/quit. Kept alive after the chain completes so tools can run under it.
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	// Drill-down job state (Phase 2).
+	tools      []Tool
+	activeJob  *job
+	pending    *pendingAction
+	jobStatus  JobStatus
+	jobToolKey string
+	jobName    string
+	jobDisplay string
+	jobOut     []string
+	jobErr     []string
+	jobDropped int64
+	jobStart   time.Time
+	facts      []Fact
+
+	toolbox   bool   // --toolbox: chain deferred until 'r'
+	exportMsg string // last export result, shown in the footer
+
+	width, height int
 }
 
 var (
 	passStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
 	failStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+	skipStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
 	faintStyle = lipgloss.NewStyle().Faint(true)
+	titleStyle = lipgloss.NewStyle().Bold(true)
+	selStyle   = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("6"))
 )
 
-func newModel(cs []Check) model {
-	rows := make([]checkRow, len(cs))
-	for i, c := range cs {
-		rows[i] = checkRow{check: c}
+func newModel(t *Target) model {
+	probes := buildProbes(t)
+	order := make([]ProbeID, len(probes))
+	byID := make(map[ProbeID]Probe, len(probes))
+	for i, p := range probes {
+		order[i] = p.ID
+		byID[p.ID] = p
 	}
 	sp := spinner.New()
 	sp.Spinner = spinner.Dot
-	return model{rows: rows, spinner: sp}
+	return model{
+		target:    t,
+		probes:    probes,
+		order:     order,
+		byID:      byID,
+		results:   map[ProbeID]ProbeResult{},
+		started:   map[ProbeID]bool{},
+		tools:     toolsFor(t),
+		jobStatus: JobQueued,
+		spinner:   sp,
+		width:     100,
+	}
 }
 
-// Init returns only the start command. It sets no state and creates no context
-// (value semantics: Init's receiver is not persisted, and a cmd cannot store a
-// context for the model).
 func (m model) Init() tea.Cmd {
-	return func() tea.Msg { return startCheckMsg{idx: 0, gen: 0} }
+	if m.toolbox {
+		return m.spinner.Tick // chain deferred until 'r'; tick drives the job timer
+	}
+	return tea.Batch(m.spinner.Tick, func() tea.Msg { return scheduleMsg{gen: 0} })
 }
+
+// chainRan reports whether the diagnostic chain has been started this session.
+func (m model) chainRan() bool { return len(m.started) > 0 }
+
+func (m model) allDone() bool { return len(m.results) == len(m.probes) }
+
+// spinnerActive reports whether the spinner tick chain should keep running:
+// while probes are pending or a drill-down job is live.
+func (m model) spinnerActive() bool { return !m.allDone() || m.activeJob != nil }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "q", "ctrl+c":
-			m.clearCancel()
-			return m, tea.Quit
-		case "r":
-			// Cancel the in-flight check, invalidate outstanding msgs via a
-			// new generation, reset to pending, and restart from the top.
-			// Does NOT touch running or seed a tick — the startCheckMsg
-			// handler decides based on the running edge.
-			m.clearCancel()
-			m.generation++
-			for i := range m.rows {
-				m.rows[i].result = nil
-			}
-			m.inFlight = 0
-			gen := m.generation
-			return m, func() tea.Msg { return startCheckMsg{idx: 0, gen: gen} }
-		}
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
 		return m, nil
 
-	case startCheckMsg:
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+
+	case scheduleMsg:
+		if msg.gen != m.generation {
+			return m, nil
+		}
+		if m.ctx == nil {
+			m.ctx, m.cancel = context.WithCancel(context.Background())
+		}
+		return m, tea.Batch(m.scheduleStep()...)
+
+	case probeDoneMsg:
 		if msg.gen != m.generation {
 			return m, nil // stale rerun
 		}
-		if msg.idx >= len(m.rows) {
-			return m, nil
-		}
-		// Create and store the per-check context synchronously — this is the
-		// single place context lifecycle is owned.
-		ctx, cancel := context.WithTimeout(context.Background(), checkTimeout)
-		m.ctx = ctx
-		m.cancel = cancel
-		m.inFlight = msg.idx
-
-		wasRunning := m.running
-		m.running = true
-
-		cmds := []tea.Cmd{func() tea.Msg {
-			return checkDoneMsg{idx: msg.idx, gen: m.generation, res: m.rows[msg.idx].check.Run(ctx)}
-		}}
-		if !wasRunning {
-			cmds = append(cmds, m.spinner.Tick) // seed exactly one tick on idle->running
-		}
-		return m, tea.Batch(cmds...)
-
-	case checkDoneMsg:
-		// Accept only the live, in-flight check for the current generation.
-		if !m.running || msg.gen != m.generation || msg.idx != m.inFlight {
-			return m, nil
-		}
-		m.clearCancel()
 		res := msg.res
-		m.rows[msg.idx].result = &res
+		res.ID = msg.id
+		m.results[msg.id] = res
+		return m, tea.Batch(m.scheduleStep()...)
 
-		if msg.idx+1 < len(m.rows) {
-			gen := m.generation
-			next := msg.idx + 1
-			return m, func() tea.Msg { return startCheckMsg{idx: next, gen: gen} }
+	case ToolOutputMsg:
+		if m.activeJob == nil || msg.Generation != m.generation || msg.JobID != m.activeJob.id {
+			return m, nil // stale job message
 		}
-		m.running = false // tick chain self-terminates
+		if msg.Stream == StreamStderr {
+			m.jobErr = appendCapped(m.jobErr, msg.Line)
+		} else {
+			m.jobOut = appendCapped(m.jobOut, msg.Line)
+		}
+		return m, waitForMsg(m.activeJob.ch)
+
+	case ToolDoneMsg:
+		if m.activeJob == nil || msg.Generation != m.generation || msg.JobID != m.activeJob.id {
+			return m, nil
+		}
+		m.jobStatus, m.jobDropped, m.activeJob = msg.Status, msg.Dropped, nil
+		m.facts = extractFacts(m.jobToolKey, m.jobOut, m.generation, msg.JobID, targetHost(m.target))
+		if m.pending != nil {
+			p := m.pending
+			m.pending = nil
+			return m.runPending(p)
+		}
 		return m, nil
 
 	case spinner.TickMsg:
 		var cmd tea.Cmd
 		m.spinner, cmd = m.spinner.Update(msg)
-		if !m.running {
-			return m, nil // drop the cmd so the chain stops
+		if !m.spinnerActive() {
+			return m, nil
 		}
 		return m, cmd
 	}
@@ -145,7 +197,198 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// clearCancel calls and nils the active check's cancel func, if any.
+func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		if m.activeJob != nil {
+			m.activeJob.cancel() // non-blocking; quit on the terminal event
+			m.pending = &pendingAction{kind: pendQuit}
+			return m, nil
+		}
+		m.clearCancel()
+		return m, tea.Quit
+	case "r":
+		if m.activeJob != nil {
+			m.activeJob.cancel()
+			m.pending = &pendingAction{kind: pendRerun}
+			return m, nil
+		}
+		return m, m.doRerun()
+	case "up", "k":
+		if m.selected > 0 {
+			m.selected--
+		}
+		return m, nil
+	case "down", "j":
+		if m.selected < len(m.order)-1 {
+			m.selected++
+		}
+		return m, nil
+	case "e":
+		if path, err := exportReport(m); err != nil {
+			m.exportMsg = "export failed: " + err.Error()
+		} else {
+			m.exportMsg = "exported → " + path
+		}
+		return m, nil
+	}
+	// Tool hotkeys (contextual toolbox).
+	for _, tool := range m.tools {
+		if msg.String() == tool.Key {
+			if m.activeJob != nil {
+				m.activeJob.cancel()
+				m.pending = &pendingAction{kind: pendTool, tool: tool} // last write wins
+				return m, nil
+			}
+			return m, m.launchTool(tool)
+		}
+	}
+	return m, nil
+}
+
+func (m *model) runPending(p *pendingAction) (tea.Model, tea.Cmd) {
+	switch p.kind {
+	case pendQuit:
+		m.clearCancel()
+		return m, tea.Quit
+	case pendRerun:
+		return m, m.doRerun()
+	case pendTool:
+		return m, m.launchTool(p.tool)
+	}
+	return m, nil
+}
+
+// doRerun bumps the generation (invalidating outstanding probe/job messages),
+// clears run + job state, resets the context, and reschedules from the root.
+func (m *model) doRerun() tea.Cmd {
+	wasTicking := m.spinnerActive()
+	m.clearCancel()
+	m.ctx = nil
+	m.generation++
+	m.results = map[ProbeID]ProbeResult{}
+	m.started = map[ProbeID]bool{}
+	m.activeJob, m.pending = nil, nil
+	m.jobStatus, m.jobOut, m.jobErr, m.facts, m.jobDropped = JobQueued, nil, nil, nil, 0
+	gen := m.generation
+	cmds := []tea.Cmd{func() tea.Msg { return scheduleMsg{gen: gen} }}
+	if !wasTicking {
+		cmds = append(cmds, m.spinner.Tick)
+	}
+	return tea.Batch(cmds...)
+}
+
+func (m *model) launchTool(tool Tool) tea.Cmd {
+	if !tool.Available() {
+		m.jobName, m.jobToolKey, m.jobStatus = tool.Name, tool.Key, JobFailed
+		m.jobOut, m.jobErr, m.facts = nil, []string{tool.Bin + " not found — install it"}, nil
+		m.jobDisplay = tool.Name
+		return nil
+	}
+	wasTicking := m.spinnerActive()
+	args, env, display := tool.Build(m.target)
+	id := fmt.Sprintf("%s-%d-%d", tool.Key, m.generation, time.Now().UnixNano())
+	j, cmd, err := startTool(m.ctx, m.generation, id, tool.Bin, args, env)
+	if err != nil {
+		m.jobName, m.jobToolKey, m.jobStatus = tool.Name, tool.Key, JobFailed
+		m.jobOut, m.jobErr, m.jobDisplay = nil, []string{sanitize(err.Error())}, display
+		return nil
+	}
+	m.activeJob, m.jobStatus = j, JobRunning
+	m.jobOut, m.jobErr, m.facts, m.jobDropped = nil, nil, nil, 0
+	m.jobName, m.jobToolKey, m.jobDisplay, m.jobStart = tool.Name, tool.Key, display, time.Now()
+	if !wasTicking {
+		return tea.Batch(cmd, m.spinner.Tick)
+	}
+	return cmd
+}
+
+// scheduleStep marks newly-skippable probes (a dependency failed) and returns run
+// commands for newly-runnable probes, repeating until no further progress so
+// skips propagate through dependents in one pass. Mutates results/started.
+func (m *model) scheduleStep() []tea.Cmd {
+	var cmds []tea.Cmd
+	for progress := true; progress; {
+		progress = false
+		for _, p := range m.probes {
+			if m.started[p.ID] {
+				continue
+			}
+			ready, blocked := depsState(p.Deps, m.results)
+			if !ready {
+				continue
+			}
+			m.started[p.ID] = true
+			progress = true
+			if blocked {
+				m.results[p.ID] = skipResult(p)
+				continue
+			}
+			cmds = append(cmds, m.runProbe(p))
+		}
+	}
+	return cmds
+}
+
+// depsState reports whether all deps completed (ready) and whether any completed
+// dep blocks this probe. A dep blocks on Fail or Skip (no output); a Pass or an
+// applicable NotApplicable (which still produced output) satisfies.
+func depsState(deps []ProbeID, res map[ProbeID]ProbeResult) (ready, blocked bool) {
+	for _, d := range deps {
+		r, ok := res[d]
+		if !ok {
+			return false, false
+		}
+		if r.Status == StatusFail || r.Status == StatusSkip {
+			blocked = true
+		}
+	}
+	return true, blocked
+}
+
+func skipResult(p Probe) ProbeResult {
+	return ProbeResult{ID: p.ID, Status: StatusSkip, Detail: "skipped — a prerequisite failed"}
+}
+
+// runProbe builds the tea.Cmd for a probe, capturing the generation, the parent
+// context, and an immutable snapshot of just its dependency outputs.
+func (m *model) runProbe(p Probe) tea.Cmd {
+	gen, parent, run, id := m.generation, m.ctx, p.Run, p.ID
+	snap := snapshot(m.results, p.Deps)
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(parent, probeTimeout)
+		defer cancel()
+		return probeDoneMsg{id: id, gen: gen, res: run(ctx, snap)}
+	}
+}
+
+// snapshot copies just the requested dependency results into a fresh map so the
+// probe goroutine never touches the live, Update-owned map.
+func snapshot(res map[ProbeID]ProbeResult, deps []ProbeID) map[ProbeID]ProbeResult {
+	out := make(map[ProbeID]ProbeResult, len(deps))
+	for _, d := range deps {
+		if r, ok := res[d]; ok {
+			out[d] = r
+		}
+	}
+	return out
+}
+
+func appendCapped(lines []string, line string) []string {
+	lines = append(lines, line)
+	if len(lines) > maxJobLines {
+		lines = lines[len(lines)-maxJobLines:]
+	}
+	return lines
+}
+
+func targetHost(t *Target) string {
+	if t == nil {
+		return ""
+	}
+	return t.Host
+}
+
 func (m *model) clearCancel() {
 	if m.cancel != nil {
 		m.cancel()
@@ -153,31 +396,136 @@ func (m *model) clearCancel() {
 	}
 }
 
+func (m model) glyph(id ProbeID) string {
+	r, ok := m.results[id]
+	if !ok {
+		return m.spinner.View()
+	}
+	switch r.Status {
+	case StatusPass:
+		return passStyle.Render("✓")
+	case StatusFail:
+		return failStyle.Render("✗")
+	case StatusSkip:
+		return skipStyle.Render("⊘")
+	case StatusNA:
+		return faintStyle.Render("–")
+	}
+	return "?"
+}
+
 func (m model) View() string {
-	var b strings.Builder
-	b.WriteString("Network Doctor\n\n")
-	for _, row := range m.rows {
-		var glyph string
-		if row.result == nil {
-			glyph = m.spinner.View()
-		} else if row.result.Status {
-			glyph = passStyle.Render("✓")
-		} else {
-			glyph = failStyle.Render("✗")
-		}
-		line := glyph + " " + row.check.Name
-		if row.result != nil && row.result.Detail != "" {
-			line += " — " + row.result.Detail
-		}
-		b.WriteString(line)
-		b.WriteByte('\n')
-		if row.result != nil && !row.result.Status && row.result.Fix != "" {
-			b.WriteString(faintStyle.Render("    → Fix: " + row.result.Fix))
-			b.WriteByte('\n')
+	leftW := 40
+	rightW := m.width - leftW - 3
+	if rightW < 36 {
+		rightW = 36
+	}
+
+	deferred := m.toolbox && !m.chainRan()
+
+	var left strings.Builder
+	left.WriteString(titleStyle.Render("Network Doctor") + "\n\n")
+	if deferred {
+		left.WriteString(faintStyle.Render("Toolbox mode.\nChain not run.\nPress r to run checks.") + "\n")
+	} else {
+		for i, id := range m.order {
+			name := m.byID[id].Name
+			if i == m.selected {
+				name = selStyle.Render("› " + name)
+			} else {
+				name = "  " + name
+			}
+			left.WriteString(m.glyph(id) + " " + name + "\n")
 		}
 	}
-	b.WriteByte('\n')
-	b.WriteString(faintStyle.Render("r: rerun · q: quit"))
-	b.WriteByte('\n')
-	return b.String()
+
+	var right strings.Builder
+	right.WriteString(titleStyle.Render("Diagnosis") + "\n\n")
+	if deferred {
+		right.WriteString("Toolbox mode — press r to run the diagnostic chain, or pick a tool below.\n")
+	} else {
+		right.WriteString(diagnose(m.target, m.order, m.results) + "\n\n")
+		id := m.order[m.selected]
+		right.WriteString(titleStyle.Render(m.byID[id].Name) + "\n")
+		if r, ok := m.results[id]; ok {
+			right.WriteString(r.Status.String() + " — " + r.Detail + "\n")
+			if r.Status == StatusFail && r.Fix != "" {
+				right.WriteString(faintStyle.Render("Fix: "+r.Fix) + "\n")
+			}
+			if r.Source != nil {
+				right.WriteString(faintStyle.Render("src "+r.Source.String()+" "+r.Iface) + "\n")
+			}
+			for _, a := range r.Attempts {
+				st := "ok"
+				if a.Err != nil {
+					st = sanitize(a.Err.Error())
+				}
+				right.WriteString(faintStyle.Render(fmt.Sprintf("  %s %dms %s", a.IP, a.Dur.Milliseconds(), st)) + "\n")
+			}
+		} else {
+			right.WriteString(faintStyle.Render("pending…") + "\n")
+		}
+	}
+
+	leftBox := lipgloss.NewStyle().Width(leftW).Render(left.String())
+	rightBox := lipgloss.NewStyle().Width(rightW).Render(right.String())
+	body := lipgloss.JoinHorizontal(lipgloss.Top, leftBox, rightBox)
+
+	help := faintStyle.Render("↑/↓ select · r rerun · e export · q quit")
+	if m.exportMsg != "" {
+		help = faintStyle.Render(m.exportMsg) + "\n" + help
+	}
+	return body + "\n" + m.toolboxView() + "\n" + m.jobView() + help + "\n"
+}
+
+func (m model) toolboxView() string {
+	if len(m.tools) == 0 {
+		return faintStyle.Render("Tools: (target-dependent — pass a host)") + "\n"
+	}
+	parts := make([]string, len(m.tools))
+	for i, t := range m.tools {
+		label := "[" + t.Key + "] " + t.Name
+		if !t.Available() {
+			label = faintStyle.Render(label + " (missing)")
+		}
+		parts[i] = label
+	}
+	return "Tools: " + strings.Join(parts, "  ") + "\n"
+}
+
+func (m model) jobView() string {
+	if m.activeJob == nil && m.jobStatus == JobQueued {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(titleStyle.Render("$ "+m.jobDisplay) + "\n")
+	status := m.jobName + " — " + m.jobStatus.String()
+	if m.activeJob != nil {
+		status += fmt.Sprintf(" (%.0fs)", time.Since(m.jobStart).Seconds())
+	}
+	b.WriteString(faintStyle.Render(status) + "\n")
+
+	for _, ln := range tail(m.jobOut, jobTailLines) {
+		b.WriteString(ln + "\n")
+	}
+	for _, ln := range tail(m.jobErr, 4) {
+		b.WriteString(faintStyle.Render("! "+ln) + "\n")
+	}
+	if len(m.facts) > 0 {
+		b.WriteString(titleStyle.Render("Extracted:") + "\n")
+		for _, f := range m.facts {
+			b.WriteString("  " + f.Key + ": " + f.Value + "\n")
+		}
+	}
+	if m.jobDropped > 0 {
+		b.WriteString(faintStyle.Render(fmt.Sprintf("(%d output lines dropped)", m.jobDropped)) + "\n")
+	}
+	return b.String() + "\n"
+}
+
+func tail(lines []string, n int) []string {
+	if len(lines) > n {
+		return lines[len(lines)-n:]
+	}
+	return lines
 }

--- a/model_test.go
+++ b/model_test.go
@@ -1,23 +1,10 @@
 package main
 
 import (
-	"context"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
-
-// testModel builds a model with n fake checks that all pass without touching
-// the network or honoring ctx (Update never actually runs the cmds here).
-func testModel(n int) model {
-	cs := make([]Check, n)
-	for i := range cs {
-		cs[i] = Check{Name: "c", Run: func(ctx context.Context) Result {
-			return Result{Status: Pass}
-		}}
-	}
-	return newModel(cs)
-}
 
 func asModel(t *testing.T, m tea.Model) model {
 	t.Helper()
@@ -28,182 +15,48 @@ func asModel(t *testing.T, m tea.Model) model {
 	return mm
 }
 
-// A startCheckMsg from a stale generation is ignored entirely.
-func TestStaleGenStartIgnored(t *testing.T) {
-	m := testModel(3)
+func keyMsg(s string) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)} }
+
+// A probeDoneMsg from a stale generation is dropped (mirrors the gen guard).
+func TestStaleProbeDropped(t *testing.T) {
+	m := newModel(nil)
 	m.generation = 5
-	u, cmd := m.Update(startCheckMsg{idx: 0, gen: 0})
+	u, cmd := m.Update(probeDoneMsg{id: pIface, gen: 0, res: ProbeResult{Status: StatusPass}})
 	nm := asModel(t, u)
-	if nm.running {
-		t.Error("stale start should not set running")
-	}
-	if nm.cancel != nil {
-		t.Error("stale start should not create a context")
+	if _, ok := nm.results[pIface]; ok {
+		t.Error("stale probe must not store a result")
 	}
 	if cmd != nil {
-		t.Error("stale start should issue no cmd")
+		t.Error("stale probe must issue no cmd")
 	}
 }
 
-// A checkDoneMsg for the wrong index (or stale gen) is ignored — it can't
-// cancel or store against the live check.
-func TestWrongDoneIgnored(t *testing.T) {
-	m := testModel(3)
-	u, _ := m.Update(startCheckMsg{idx: 0, gen: 0})
-	m = asModel(t, u)
-	ctx0 := m.ctx
-
-	// wrong index
-	u, cmd := m.Update(checkDoneMsg{idx: 1, gen: 0, res: Result{Status: Pass}})
-	nm := asModel(t, u)
-	if nm.rows[1].result != nil || nm.rows[0].result != nil {
-		t.Error("wrong-index done must not store a result")
-	}
-	if cmd != nil || !nm.running {
-		t.Error("wrong-index done must be a no-op on flow")
-	}
-	if ctx0.Err() != nil {
-		t.Error("wrong-index done must not cancel the live context")
-	}
-
-	// stale generation
-	u, cmd = m.Update(checkDoneMsg{idx: 0, gen: 99, res: Result{Status: Pass}})
-	nm = asModel(t, u)
-	if nm.rows[0].result != nil || cmd != nil {
-		t.Error("stale-gen done must be ignored")
-	}
-}
-
-// Happy path: each completion stores its result, cancels its context, advances,
-// and the tick chain self-terminates after the last check.
-func TestCompletesAdvancesAndCancels(t *testing.T) {
-	m := testModel(2)
-
-	u, _ := m.Update(startCheckMsg{idx: 0, gen: 0})
-	m = asModel(t, u)
-	if !m.running || m.inFlight != 0 || m.cancel == nil {
-		t.Fatal("first start should be running with a live context")
-	}
-	ctx0 := m.ctx
-
-	u, cmd := m.Update(checkDoneMsg{idx: 0, gen: 0, res: Result{Status: Pass, Detail: "ok"}})
-	m = asModel(t, u)
-	if m.rows[0].result == nil || !m.rows[0].result.Status {
-		t.Fatal("result for check 0 not stored")
-	}
-	if ctx0.Err() != context.Canceled {
-		t.Error("completing a check must cancel its context")
-	}
-	if m.cancel != nil {
-		t.Error("cancel must be cleared after completion")
-	}
-	if cmd == nil {
-		t.Fatal("expected a start cmd for the next check")
-	}
-
-	next, ok := cmd().(startCheckMsg)
-	if !ok || next.idx != 1 || next.gen != 0 {
-		t.Fatalf("expected startCheckMsg{1,0}, got %#v", cmd())
-	}
-
-	u, _ = m.Update(next)
-	m = asModel(t, u)
-	if m.inFlight != 1 || !m.running || m.cancel == nil {
-		t.Fatal("second check should be in flight")
-	}
-	ctx1 := m.ctx
-
-	u, cmd = m.Update(checkDoneMsg{idx: 1, gen: 0, res: Result{Status: Pass}})
-	m = asModel(t, u)
-	if m.rows[1].result == nil {
-		t.Fatal("result for check 1 not stored")
-	}
-	if m.running {
-		t.Error("running should be false after the last check")
-	}
-	if ctx1.Err() != context.Canceled || m.cancel != nil {
-		t.Error("last check's context must be cancelled and cleared")
-	}
-	if cmd != nil {
-		t.Error("no cmd should follow the final check")
-	}
-}
-
-// 'r' cancels the live check, bumps generation, resets to pending, restarts at
-// 0, and leaves running untouched (the startCheckMsg handler owns the tick).
-func TestRerunCancelsAndRestarts(t *testing.T) {
-	m := testModel(2)
-	u, _ := m.Update(startCheckMsg{idx: 0, gen: 0})
-	m = asModel(t, u)
-	ctx0 := m.ctx
+// 'r' bumps the generation, clears run state, and resets the context.
+func TestRerunResets(t *testing.T) {
+	m := newModel(nil)
+	m.results[pIface] = ProbeResult{Status: StatusPass}
+	m.started[pIface] = true
 	gen0 := m.generation
-
 	u, cmd := m.Update(keyMsg("r"))
-	m = asModel(t, u)
-	if ctx0.Err() != context.Canceled {
-		t.Error("'r' must cancel the in-flight context")
+	nm := asModel(t, u)
+	if nm.generation != gen0+1 {
+		t.Errorf("generation = %d, want %d", nm.generation, gen0+1)
 	}
-	if m.cancel != nil {
-		t.Error("'r' must clear cancel")
+	if len(nm.results) != 0 || len(nm.started) != 0 {
+		t.Error("rerun must clear results/started")
 	}
-	if m.generation != gen0+1 {
-		t.Errorf("generation = %d, want %d", m.generation, gen0+1)
-	}
-	for i, row := range m.rows {
-		if row.result != nil {
-			t.Errorf("row %d not reset to pending", i)
-		}
-	}
-	if m.inFlight != 0 {
-		t.Error("'r' must reset inFlight to 0")
+	if nm.ctx != nil {
+		t.Error("rerun must reset ctx to nil")
 	}
 	if cmd == nil {
-		t.Fatal("'r' must issue a restart cmd")
-	}
-	restart, ok := cmd().(startCheckMsg)
-	if !ok || restart.idx != 0 || restart.gen != gen0+1 {
-		t.Fatalf("expected startCheckMsg{0,%d}, got %#v", gen0+1, cmd())
+		t.Fatal("rerun must issue a cmd")
 	}
 }
 
-// After all checks finish (running==false), 'r' then startCheckMsg restarts the
-// run — running goes true again and a fresh context is created.
-func TestRerunAfterCompletionRestarts(t *testing.T) {
-	m := testModel(1)
-	u, _ := m.Update(startCheckMsg{idx: 0, gen: 0})
-	m = asModel(t, u)
-	u, _ = m.Update(checkDoneMsg{idx: 0, gen: 0, res: Result{Status: Pass}})
-	m = asModel(t, u)
-	if m.running {
-		t.Fatal("precondition: running should be false after completion")
-	}
-
-	u, cmd := m.Update(keyMsg("r"))
-	m = asModel(t, u)
-	restart := cmd().(startCheckMsg)
-
-	u, cmd = m.Update(restart)
-	m = asModel(t, u)
-	if !m.running || m.inFlight != 0 || m.cancel == nil {
-		t.Fatal("post-completion rerun must restart the run")
-	}
-	if cmd == nil {
-		t.Error("restart should issue cmds (runCheck + seeded tick)")
-	}
-}
-
-// 'q' / ctrl+c cancel the live check and quit.
-func TestQuitCancels(t *testing.T) {
-	m := testModel(2)
-	u, _ := m.Update(startCheckMsg{idx: 0, gen: 0})
-	m = asModel(t, u)
-	ctx0 := m.ctx
-
+func TestQuit(t *testing.T) {
+	m := newModel(nil)
 	u, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
-	m = asModel(t, u)
-	if ctx0.Err() != context.Canceled || m.cancel != nil {
-		t.Error("quit must cancel and clear the live context")
-	}
+	_ = asModel(t, u)
 	if cmd == nil {
 		t.Fatal("quit must return a cmd")
 	}
@@ -212,24 +65,53 @@ func TestQuitCancels(t *testing.T) {
 	}
 }
 
-// The spinner tick reschedules only while running; the chain stops otherwise.
-func TestSpinnerTickGate(t *testing.T) {
-	m := testModel(1)
-	tick := m.spinner.Tick() // a real spinner.TickMsg with the right id
-
-	m.running = true
-	_, cmd := m.Update(tick)
-	if cmd == nil {
-		t.Error("tick should reschedule while running")
+// scheduleMsg creates the generation context and dispatches only the root probe.
+func TestScheduleStartsRoot(t *testing.T) {
+	m := newModel(nil)
+	u, cmd := m.Update(scheduleMsg{gen: 0})
+	nm := asModel(t, u)
+	if nm.ctx == nil {
+		t.Error("scheduleMsg must create the generation context")
 	}
-
-	m.running = false
-	_, cmd = m.Update(tick)
-	if cmd != nil {
-		t.Error("tick should not reschedule once stopped")
+	if !nm.started[pIface] {
+		t.Error("iface (root) should be dispatched")
+	}
+	if nm.started[pInternet] || nm.started[pDNS] {
+		t.Error("dependants of iface must wait")
+	}
+	if cmd == nil {
+		t.Error("expected a dispatch cmd")
 	}
 }
 
-func keyMsg(s string) tea.KeyMsg {
-	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+func TestSelectionClamp(t *testing.T) {
+	m := newModel(nil) // 3 rows
+	u, _ := m.Update(keyMsg("k"))
+	if asModel(t, u).selected != 0 {
+		t.Error("up at top must stay 0")
+	}
+	for i := 0; i < 5; i++ {
+		u, _ = m.Update(keyMsg("j"))
+		m = asModel(t, u)
+	}
+	if m.selected != 2 {
+		t.Errorf("selected = %d, want clamp at 2", m.selected)
+	}
+}
+
+func TestExitCode(t *testing.T) {
+	m := newModel(nil)
+	if exitCode(m) != 1 {
+		t.Error("unfinished chain must exit 1")
+	}
+	for _, id := range m.order {
+		m.results[id] = ProbeResult{Status: StatusPass}
+	}
+	if exitCode(m) != 0 {
+		t.Error("all-pass must exit 0")
+	}
+	m.results[pDNS] = ProbeResult{Status: StatusFail}
+	if exitCode(m) != 1 {
+		t.Error("a fail must exit 1")
+	}
 }

--- a/sanitize.go
+++ b/sanitize.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// escapeRe matches the escape sequences we strip from untrusted text:
+// CSI (ESC [ ... final), OSC (ESC ] ... BEL|ST), and any other two-byte
+// ESC sequence. Ordered CSI/OSC first so the generic 2-byte form can't swallow
+// a CSI/OSC introducer.
+var escapeRe = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b[@-_]`)
+
+// sanitize strips ANSI/OSC/CSI escape sequences and control runes from text that
+// originates from external tools or remote servers (banners, error strings), so
+// a hostile peer can't drive the terminal. Tabs become spaces; everything else
+// in the control range (incl. lone ESC, C1, newlines) and invalid UTF-8 is
+// dropped. ponytail: single-line oriented — keep newlines too when multi-line
+// tool output lands in Phase 2.
+func sanitize(s string) string {
+	s = escapeRe.ReplaceAllString(s, "")
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r == '\t':
+			return ' '
+		case r == unicode.ReplacementChar: // invalid UTF-8 decoded byte
+			return -1
+		case unicode.IsControl(r): // C0 + C1, incl. ESC and \n
+			return -1
+		default:
+			return r
+		}
+	}, s)
+}

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"unicode"
+	"unicode/utf8"
+)
+
+func noControl(t *testing.T, in, out string) {
+	t.Helper()
+	if !utf8.ValidString(out) {
+		t.Errorf("sanitize(%q) produced invalid UTF-8: %q", in, out)
+	}
+	for _, r := range out {
+		if r != ' ' && unicode.IsControl(r) {
+			t.Errorf("sanitize(%q) left control rune %U in %q", in, r, out)
+		}
+	}
+	if strings.ContainsRune(out, 0x1b) {
+		t.Errorf("sanitize(%q) left ESC: %q", in, out)
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	cases := []string{
+		"\x1b[31mred\x1b[0m",
+		"\x1b]0;title\x07evil",
+		"plain\x00\x07\x1bbad",
+		"line1\nline2",
+		"\x1b[2J\x1b[H",
+		"tab\there",
+		"\x9b31m raw c1 byte",
+		"\xff\xfe invalid utf8",
+	}
+	for _, in := range cases {
+		noControl(t, in, sanitize(in))
+	}
+	if got := sanitize("\x1b[31mhello\x1b[0m"); got != "hello" {
+		t.Errorf("escape strip = %q, want %q", got, "hello")
+	}
+}
+
+func FuzzSanitize(f *testing.F) {
+	for _, s := range []string{"\x1b[31mhi\x1b[0m", "\x1b]0;x\x07", "\xff\xfe", "ok"} {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		noControl(t, s, sanitize(s))
+	})
+}

--- a/target.go
+++ b/target.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Proto selects which protocol-specific probe rows append to the target path.
+type Proto int
+
+const (
+	ProtoNone Proto = iota // stop at Target TCP — no protocol-specific check
+	ProtoTLSHTTP
+	ProtoHTTP
+	ProtoSSH
+	ProtoSMTP
+)
+
+// Target is the parsed, validated destination. Two independent axes: the
+// endpoint Port (explicit > scheme default > 443) and the Proto of the
+// protocol rows (explicit scheme wins; else inferred from the effective port).
+type Target struct {
+	Host         string
+	IP           net.IP // set iff IsLiteral
+	Port         int
+	Scheme       string
+	Proto        Proto
+	PortExplicit bool
+	IsLiteral    bool
+	Raw          string
+}
+
+// hostnameRe is a strict RFC-1123-ish hostname allowlist (labels of
+// alphanumerics + internal hyphens, dot-separated). Everything else is rejected
+// so nothing user-supplied is ever fed to a probe or (later) a command.
+var hostnameRe = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$`)
+
+// parseTarget parses a CLI target: <host> | <host>:<port> | http(s)://<host>[:port][/path].
+// IPv6 literals are rejected (out of scope). Returns a typed Target or an error
+// (caller exits 2 on error).
+func parseTarget(raw string) (*Target, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return nil, errors.New("empty target")
+	}
+	t := &Target{Raw: raw}
+
+	if i := strings.Index(s, "://"); i >= 0 {
+		t.Scheme = strings.ToLower(s[:i])
+		if t.Scheme != "http" && t.Scheme != "https" {
+			return nil, fmt.Errorf("unsupported scheme %q (only http/https)", t.Scheme)
+		}
+		s = s[i+3:]
+	}
+	// Drop any path/query/fragment.
+	if i := strings.IndexAny(s, "/?#"); i >= 0 {
+		s = s[:i]
+	}
+	if s == "" {
+		return nil, errors.New("missing host")
+	}
+	// IPv6 literal forms (bracketed, or >1 colon) are out of scope.
+	if strings.ContainsAny(s, "[]") || strings.Count(s, ":") > 1 {
+		return nil, errors.New("IPv6 literals are out of scope (IPv4 only)")
+	}
+
+	host := s
+	if i := strings.LastIndex(s, ":"); i >= 0 {
+		host = s[:i]
+		port, err := strconv.Atoi(s[i+1:])
+		if err != nil || port < 1 || port > 65535 {
+			return nil, fmt.Errorf("invalid port %q", s[i+1:])
+		}
+		t.Port = port
+		t.PortExplicit = true
+	}
+	if host == "" {
+		return nil, errors.New("missing host")
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.To4() == nil {
+			return nil, errors.New("IPv6 literals are out of scope (IPv4 only)")
+		}
+		t.IsLiteral = true
+		t.IP = ip.To4()
+		t.Host = host
+	} else {
+		if len(host) > 253 || !hostnameRe.MatchString(host) {
+			return nil, fmt.Errorf("invalid hostname %q", host)
+		}
+		t.Host = host
+	}
+
+	// Endpoint port: explicit > scheme default > 443.
+	if !t.PortExplicit {
+		switch t.Scheme {
+		case "http":
+			t.Port = 80
+		default: // https or bare host
+			t.Port = 443
+		}
+	}
+
+	// Protocol rows: explicit scheme wins; else infer from the effective port.
+	switch t.Scheme {
+	case "https":
+		t.Proto = ProtoTLSHTTP
+	case "http":
+		t.Proto = ProtoHTTP
+	default:
+		switch t.Port {
+		case 443, 8443:
+			t.Proto = ProtoTLSHTTP
+		case 80:
+			t.Proto = ProtoHTTP
+		case 22:
+			t.Proto = ProtoSSH
+		case 25, 587:
+			t.Proto = ProtoSMTP
+		default:
+			t.Proto = ProtoNone
+		}
+	}
+	return t, nil
+}

--- a/target_test.go
+++ b/target_test.go
@@ -1,0 +1,54 @@
+package main
+
+import "testing"
+
+func TestParseTarget(t *testing.T) {
+	cases := []struct {
+		in      string
+		host    string
+		port    int
+		proto   Proto
+		literal bool
+	}{
+		{"github.com", "github.com", 443, ProtoTLSHTTP, false},
+		{"github.com:22", "github.com", 22, ProtoSSH, false},
+		{"https://github.com", "github.com", 443, ProtoTLSHTTP, false},
+		{"http://example.com", "example.com", 80, ProtoHTTP, false},
+		{"https://host:80", "host", 80, ProtoTLSHTTP, false}, // scheme selects proto
+		{"http://host:443", "host", 443, ProtoHTTP, false},   // scheme selects proto
+		{"1.1.1.1", "1.1.1.1", 443, ProtoTLSHTTP, true},
+		{"1.1.1.1:25", "1.1.1.1", 25, ProtoSMTP, true},
+		{"mail.example.com:587", "mail.example.com", 587, ProtoSMTP, false},
+		{"https://github.com/owner/repo", "github.com", 443, ProtoTLSHTTP, false},
+		{"host:8443", "host", 8443, ProtoTLSHTTP, false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			tg, err := parseTarget(c.in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tg.Host != c.host {
+				t.Errorf("host = %q, want %q", tg.Host, c.host)
+			}
+			if tg.Port != c.port {
+				t.Errorf("port = %d, want %d", tg.Port, c.port)
+			}
+			if tg.Proto != c.proto {
+				t.Errorf("proto = %d, want %d", tg.Proto, c.proto)
+			}
+			if tg.IsLiteral != c.literal {
+				t.Errorf("literal = %v, want %v", tg.IsLiteral, c.literal)
+			}
+		})
+	}
+}
+
+func TestParseTargetErrors(t *testing.T) {
+	bad := []string{"", "::1", "[::1]:443", "host:0", "host:99999", "ftp://host", "bad_host!", "fe80::1"}
+	for _, in := range bad {
+		if tg, err := parseTarget(in); err == nil {
+			t.Errorf("parseTarget(%q) = %+v, want error", in, tg)
+		}
+	}
+}

--- a/toolbox_test.go
+++ b/toolbox_test.go
@@ -1,0 +1,46 @@
+package main
+
+import "testing"
+
+func TestToolsFor(t *testing.T) {
+	// Generic mode: target-independent tools only (ip, ss).
+	if got := len(toolsFor(nil)); got != 2 {
+		t.Errorf("toolsFor(nil) = %d, want 2 (ip, ss)", got)
+	}
+	// Target mode: + ping, dig, curl, traceroute, mtr.
+	if got := len(toolsFor(mustTarget(t, "github.com"))); got != 7 {
+		t.Errorf("toolsFor(target) = %d, want 7", got)
+	}
+}
+
+func TestToolHotkeysUnique(t *testing.T) {
+	seen := map[string]bool{}
+	reserved := map[string]bool{"q": true, "r": true, "e": true, "j": true, "k": true}
+	for _, tool := range toolsFor(mustTarget(t, "github.com")) {
+		if seen[tool.Key] {
+			t.Errorf("duplicate tool hotkey %q", tool.Key)
+		}
+		if reserved[tool.Key] {
+			t.Errorf("tool hotkey %q collides with a reserved key", tool.Key)
+		}
+		seen[tool.Key] = true
+	}
+}
+
+// Toolbox mode with no chain run exits 0.
+func TestToolboxExitZero(t *testing.T) {
+	m := newModel(nil)
+	m.toolbox = true
+	if exitCode(m) != 0 {
+		t.Error("toolbox mode, no chain run, must exit 0")
+	}
+	// Once the chain runs and a probe fails, normal rules apply.
+	m.started[pIface] = true
+	for _, id := range m.order {
+		m.results[id] = ProbeResult{Status: StatusPass}
+	}
+	m.results[pDNS] = ProbeResult{Status: StatusFail}
+	if exitCode(m) != 1 {
+		t.Error("toolbox mode after a failed chain must exit 1")
+	}
+}

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Tool is a drill-down adapter: a bounded external command keyed to a hotkey.
+type Tool struct {
+	Key  string // single-key hotkey / stable id
+	Name string // display label
+	Bin  string // binary to resolve via LookPath
+	// Build returns the argv (never a shell string), the process env (nil =
+	// inherit), and a human-display command string (shell-quoted, display only).
+	Build func(t *Target) (args, env []string, display string)
+}
+
+// Available reports whether the tool's binary is installed.
+func (t Tool) Available() bool {
+	_, err := exec.LookPath(t.Bin)
+	return err == nil
+}
+
+// toolsFor returns the drill-down tools applicable to the target. The
+// target-independent tools (ip route, ss) are always offered; the
+// target-dependent set (ping, dig, curl, traceroute, mtr) only when a host is
+// given.
+func toolsFor(t *Target) []Tool {
+	tools := []Tool{
+		{
+			Key: "i", Name: "ip route", Bin: "ip",
+			Build: func(*Target) ([]string, []string, string) {
+				args := []string{"route"}
+				return args, nil, "ip " + shellArgs(args)
+			},
+		},
+		{
+			Key: "s", Name: "ss", Bin: "ss",
+			Build: func(*Target) ([]string, []string, string) {
+				args := []string{"-tunp"}
+				return args, nil, "ss " + shellArgs(args)
+			},
+		},
+	}
+	if t == nil {
+		return tools
+	}
+	host := t.Host
+	return append(tools,
+		Tool{
+			Key: "p", Name: "ping", Bin: "ping",
+			Build: func(*Target) ([]string, []string, string) {
+				args := []string{"-c", "4", "-W", "2", host}
+				return args, nil, "ping " + shellArgs(args)
+			},
+		},
+		Tool{
+			Key: "d", Name: "dig", Bin: "dig",
+			Build: func(*Target) ([]string, []string, string) {
+				args := []string{"+time=2", "+tries=1", host}
+				return args, nil, "dig " + shellArgs(args)
+			},
+		},
+		Tool{
+			Key: "c", Name: "curl", Bin: "curl",
+			Build: func(t *Target) ([]string, []string, string) {
+				url := schemeFor(t) + "://" + host
+				if t.PortExplicit {
+					url += ":" + strconv.Itoa(t.Port)
+				}
+				args := []string{
+					"-q", "-sS", "--head", "-o", "/dev/null",
+					"--max-redirs", "0", "--noproxy", "*",
+					"--proto", "=https,http",
+					"--connect-timeout", "3", "--max-time", "10",
+					"-w", `%{http_code} %{time_total} %{remote_ip} %{ssl_verify_result}\n`,
+					url,
+				}
+				// LC_ALL=C is set via env, not an argv token, for locale-proof -w output.
+				env := append(os.Environ(), "LC_ALL=C")
+				return args, env, "LC_ALL=C curl " + shellArgs(args)
+			},
+		},
+		Tool{
+			Key: "t", Name: "traceroute", Bin: "traceroute",
+			Build: func(*Target) ([]string, []string, string) {
+				args := []string{"-w", "2", "-q", "1", "-m", "20", host}
+				return args, nil, "traceroute " + shellArgs(args)
+			},
+		},
+		Tool{
+			Key: "m", Name: "mtr", Bin: "mtr",
+			Build: func(*Target) ([]string, []string, string) {
+				// report mode only — never curses inside our TUI.
+				args := []string{"--report", "--report-cycles", "5", host}
+				return args, nil, "mtr " + shellArgs(args)
+			},
+		},
+	)
+}
+
+func schemeFor(t *Target) string {
+	if t.Proto == ProtoHTTP {
+		return "http"
+	}
+	return "https"
+}
+
+// shellArgs renders argv for *display only* (never executed), quoting tokens with
+// shell-special characters so the shown command is copy-pasteable.
+func shellArgs(args []string) string {
+	out := make([]string, len(args))
+	for i, a := range args {
+		if a == "" || strings.ContainsAny(a, " \t\"'\\$*?#&|;<>(){}[]`") {
+			out[i] = "'" + strings.ReplaceAll(a, "'", `'\''`) + "'"
+		} else {
+			out[i] = a
+		}
+	}
+	return strings.Join(out, " ")
+}
+
+// Confidence grades a best-effort extracted fact.
+type Confidence int
+
+const (
+	Low Confidence = iota
+	Medium
+	High
+)
+
+// Fact is a typed, generation-scoped datum extracted from a finished tool's
+// output. Facts are display-only evidence — they never feed the diagnosis.
+type Fact struct {
+	Key, Value string
+	Confidence Confidence
+	Source     string
+	Target     string
+	Generation int
+	JobID      string
+	At         time.Time
+}
+
+// extractFacts pulls a few stable facts from a finished tool's stdout. Best
+// effort across tool versions; the raw (sanitized) output stays authoritative.
+func extractFacts(toolKey string, stdout []string, gen int, jobID, target string) []Fact {
+	mk := func(k, v string, c Confidence) Fact {
+		return Fact{Key: k, Value: v, Confidence: c, Source: toolKey, Target: target, Generation: gen, JobID: jobID, At: time.Now()}
+	}
+	var facts []Fact
+	switch toolKey {
+	case "c": // curl -w "http_code time_total remote_ip ssl_verify_result"
+		for i := len(stdout) - 1; i >= 0; i-- {
+			f := strings.Fields(stdout[i])
+			if len(f) == 4 {
+				facts = append(facts,
+					mk("http_code", f[0], High),
+					mk("time_total", f[1]+"s", High),
+					mk("remote_ip", f[2], High),
+					mk("ssl_verify", f[3], Medium))
+				break
+			}
+		}
+	case "p": // ping: "rtt min/avg/max/mdev = a/b/c/d ms" and "X% packet loss"
+		for _, ln := range stdout {
+			if i := strings.Index(ln, "packet loss"); i >= 0 {
+				end := i + len("packet loss")
+				if j := strings.LastIndex(ln[:i], ","); j >= 0 {
+					facts = append(facts, mk("packet_loss", strings.TrimSpace(ln[j+1:end]), High))
+				}
+			}
+			if i := strings.Index(ln, "min/avg/max"); i >= 0 {
+				if eq := strings.Index(ln, "="); eq >= 0 {
+					facts = append(facts, mk("rtt", strings.TrimSpace(ln[eq+1:]), High))
+				}
+			}
+		}
+	case "d": // dig: collect answer-section A records
+		var as []string
+		for _, ln := range stdout {
+			f := strings.Fields(ln)
+			if len(f) >= 5 && f[3] == "A" {
+				as = append(as, f[4])
+			}
+		}
+		if len(as) > 0 {
+			facts = append(facts, mk("A_records", strings.Join(as, ", "), High))
+		}
+	}
+	return facts
+}

--- a/tools_test.go
+++ b/tools_test.go
@@ -1,0 +1,62 @@
+package main
+
+import "testing"
+
+func factVal(facts []Fact, key string) (string, bool) {
+	for _, f := range facts {
+		if f.Key == key {
+			return f.Value, true
+		}
+	}
+	return "", false
+}
+
+func TestExtractCurl(t *testing.T) {
+	stdout := []string{"200 0.123456 140.82.112.3 0"}
+	facts := extractFacts("c", stdout, 1, "job1", "github.com")
+	if v, ok := factVal(facts, "http_code"); !ok || v != "200" {
+		t.Errorf("http_code = %q (%v), want 200", v, ok)
+	}
+	if v, ok := factVal(facts, "remote_ip"); !ok || v != "140.82.112.3" {
+		t.Errorf("remote_ip = %q, want 140.82.112.3", v)
+	}
+	if v, ok := factVal(facts, "time_total"); !ok || v != "0.123456s" {
+		t.Errorf("time_total = %q, want 0.123456s", v)
+	}
+}
+
+func TestExtractPing(t *testing.T) {
+	stdout := []string{
+		"PING github.com (140.82.112.3) 56(84) bytes of data.",
+		"4 packets transmitted, 4 received, 0% packet loss, time 3005ms",
+		"rtt min/avg/max/mdev = 1.0/2.0/3.0/0.5 ms",
+	}
+	facts := extractFacts("p", stdout, 1, "job1", "github.com")
+	if v, ok := factVal(facts, "packet_loss"); !ok || v != "0% packet loss" {
+		t.Errorf("packet_loss = %q, want '0%% packet loss'", v)
+	}
+	if v, ok := factVal(facts, "rtt"); !ok || v != "1.0/2.0/3.0/0.5 ms" {
+		t.Errorf("rtt = %q, want '1.0/2.0/3.0/0.5 ms'", v)
+	}
+}
+
+func TestExtractDig(t *testing.T) {
+	stdout := []string{
+		";; ANSWER SECTION:",
+		"github.com.\t60\tIN\tA\t140.82.112.3",
+		"github.com.\t60\tIN\tA\t140.82.113.4",
+	}
+	facts := extractFacts("d", stdout, 1, "job1", "github.com")
+	v, ok := factVal(facts, "A_records")
+	if !ok || v != "140.82.112.3, 140.82.113.4" {
+		t.Errorf("A_records = %q, want both IPs", v)
+	}
+}
+
+func TestShellArgsQuotes(t *testing.T) {
+	got := shellArgs([]string{"-w", `%{http_code}\n`, "https://x"})
+	want := `-w '%{http_code}\n' https://x`
+	if got != want {
+		t.Errorf("shellArgs = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Rework network-doctor from a flat in-process check list into a diagnosis-first TUI that unifies external network tools. Native, rootless probes form a dependency graph (two paths so an unrelated failure never hides a working one), a diagnosis engine turns their combined state into a plain-English verdict, and external tools run as cancellable streaming jobs for on-demand evidence.

Phase 1 — native core:
- target.go: typed parser (port vs protocol axes, scheme-selects-proto, strict host allowlist, IPv6 rejected)
- checks.go: ProbeResult contract + four-state Status/FailClass; two-path DAG; multi-A-record resolve-all + per-address budget + pin-first; hybrid path identity (TCP LocalAddr, UDP fallback) mapped to an interface
- diagnosis.go: verdict from native state only
- model.go: two-pane UI, Update-owned results with immutable snapshots, generation staleness guard

Phase 2 — streaming job engine:
- jobs.go: process-group exec, drain-before-wait, single FIFO with a guaranteed terminal event, bounded non-blocking buffers + line truncation, success-wins terminal classification
- tools.go: ping/dig/curl adapters (arg slice, LC_ALL=C via env), LookPath, fact extraction
- model.go: contextual toolbox, job pane, non-blocking pending-action keymap

Phase 3:
- traceroute/mtr/ss/ip adapters; export.go (0600, no-clobber, sanitized + indented code blocks); --toolbox mode; exit-code table