### PR TITLE
Probe ALL_PROXY and SOCKS5 proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Each row lands in one of five states: **✓ Pass**, **! Warn** (reachable but de
 |-------|-------------|-------|
 | **Interface** | A non-loopback interface is up and running | |
 | **Internet (TCP egress)** | A TCP connect to well-known anycast `:443` endpoints succeeds | IPv4 and IPv6 probed independently in parallel; either family passes, both are reported |
-| **Internet (env proxy)** | The `HTTPS_PROXY`/`HTTP_PROXY` proxy grants a `CONNECT` tunnel | N/A when no proxy is configured; honors `NO_PROXY` |
+| **Internet (env proxy)** | The `HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY` proxy grants a tunnel | HTTP `CONNECT`, or a SOCKS5 handshake for `socks5`/`socks5h`; N/A when no proxy is configured; honors `NO_PROXY` for `HTTPS_PROXY`/`HTTP_PROXY` |
 | **DNS** | The host resolves to an IPv4 or IPv6 address (system resolution) | IP-literal targets are N/A; all A/AAAA records are retained |
 | **DNS (public 8.8.8.8)** | A direct query to Google Public DNS provides a second opinion | N/A when outbound DNS is unavailable; disagreement is Warn, not Fail |
 | **TCP** | A TCP connect to the target port succeeds | races A/AAAA records Happy-Eyeballs style (RFC 8305), pins the winner |

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Each row lands in one of five states: **✓ Pass**, **! Warn** (reachable but de
 |-------|-------------|-------|
 | **Interface** | A non-loopback interface is up and running | |
 | **Internet (TCP egress)** | A TCP connect to well-known anycast `:443` endpoints succeeds | IPv4 and IPv6 probed independently in parallel; either family passes, both are reported |
-| **Internet (env proxy)** | The `HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY` proxy grants a tunnel | HTTP `CONNECT`, or a SOCKS5 handshake for `socks5`/`socks5h`; N/A when no proxy is configured; honors `NO_PROXY` for `HTTPS_PROXY`/`HTTP_PROXY` |
+| **Internet (env proxy)** | The `HTTPS_PROXY`/`HTTP_PROXY`/`ALL_PROXY` proxy grants a tunnel | HTTP `CONNECT`, or a SOCKS5 handshake for `socks5`/`socks5h`; N/A when no proxy is configured or `NO_PROXY` exempts the probe host |
 | **DNS** | The host resolves to an IPv4 or IPv6 address (system resolution) | IP-literal targets are N/A; all A/AAAA records are retained |
 | **DNS (public 8.8.8.8)** | A direct query to Google Public DNS provides a second opinion | N/A when outbound DNS is unavailable; disagreement is Warn, not Fail |
 | **TCP** | A TCP connect to the target port succeeds | races A/AAAA records Happy-Eyeballs style (RFC 8305), pins the winner |

--- a/internal/diagnostic/checks.go
+++ b/internal/diagnostic/checks.go
@@ -960,9 +960,10 @@ func socks5Connect(conn net.Conn) error {
 	return nil
 }
 
-// socks5Error names an RFC 1928 reply code.
+// socks5Error names an RFC 1928 reply code. Codes 6-8 can't come back from a
+// domain-name CONNECT, so they fall through to the number.
 func socks5Error(code byte) string {
-	msgs := [...]string{1: "general failure", 2: "not allowed by ruleset", 3: "network unreachable", 4: "host unreachable", 5: "connection refused", 6: "TTL expired", 7: "command not supported", 8: "address type not supported"}
+	msgs := [...]string{1: "general failure", 2: "not allowed by ruleset", 3: "network unreachable", 4: "host unreachable", 5: "connection refused"}
 	if int(code) < len(msgs) && msgs[code] != "" {
 		return msgs[code]
 	}

--- a/internal/diagnostic/checks.go
+++ b/internal/diagnostic/checks.go
@@ -778,10 +778,10 @@ func (o *netops) proxyProbe(ctx context.Context, _ map[ProbeID]ProbeResult) Prob
 	addr := proxyURL.Host
 	if proxyURL.Port() == "" {
 		port := "80"
-		switch {
-		case proxyURL.Scheme == "https":
+		switch proxyURL.Scheme {
+		case "https":
 			port = "443"
-		case socks:
+		case "socks5", "socks5h":
 			port = "1080"
 		}
 		addr = net.JoinHostPort(proxyURL.Hostname(), port)

--- a/internal/diagnostic/checks.go
+++ b/internal/diagnostic/checks.go
@@ -960,10 +960,11 @@ func socks5Connect(conn net.Conn) error {
 	return nil
 }
 
-// socks5Error names an RFC 1928 reply code. Codes 6-8 can't come back from a
-// domain-name CONNECT, so they fall through to the number.
+// socks5Error names an RFC 1928 reply code. Codes 6-7 can't come back from a
+// CONNECT, so they fall through to the number; 8 can, because this probe always
+// asks for ATYP 3.
 func socks5Error(code byte) string {
-	msgs := [...]string{1: "general failure", 2: "not allowed by ruleset", 3: "network unreachable", 4: "host unreachable", 5: "connection refused"}
+	msgs := [...]string{1: "general failure", 2: "not allowed by ruleset", 3: "network unreachable", 4: "host unreachable", 5: "connection refused", 8: "address type not supported"}
 	if int(code) < len(msgs) && msgs[code] != "" {
 		return msgs[code]
 	}

--- a/internal/diagnostic/checks.go
+++ b/internal/diagnostic/checks.go
@@ -911,11 +911,9 @@ func (o *netops) socks5Probe(ctx context.Context, addr string, dl, start time.Ti
 // tunnel to host:port. Credentials are never offered: the SOCKS5
 // username/password exchange (RFC 1929) is cleartext, and this probe already
 // refuses to spend credentials on an unencrypted hop. Every read is a fixed,
-// small size — the replies are attacker-controlled.
+// small size — the replies are attacker-controlled. host must be at most 255
+// bytes; the only caller passes the probeHost constant.
 func socks5Connect(conn net.Conn, host string, port int) error {
-	if len(host) > 255 {
-		return errors.New("hostname too long for SOCKS5")
-	}
 	// VER 5, offering exactly one method: 0 (no authentication).
 	if _, err := conn.Write([]byte{5, 1, 0}); err != nil {
 		return fmt.Errorf("greeting failed: %w", err)

--- a/internal/diagnostic/checks.go
+++ b/internal/diagnostic/checks.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -235,7 +236,7 @@ var defaultOps = &netops{
 		return d.DialContext(ctx, network, addr)
 	},
 	ssid:         ssid,
-	proxyFromEnv: http.ProxyFromEnvironment,
+	proxyFromEnv: proxyFromEnvironment,
 	portalCheck: func(ctx context.Context) (int, string, error) {
 		return portalCheckWithDial(ctx, new(net.Dialer).DialContext)
 	},
@@ -701,9 +702,35 @@ func (o *netops) internetProbe(ctx context.Context, _ map[ProbeID]ProbeResult) P
 	return r
 }
 
+// proxyFromEnvironment is http.ProxyFromEnvironment plus ALL_PROXY, which Go
+// ignores but curl, ssh and the SOCKS ecosystem honor — a box whose only proxy
+// setting is ALL_PROXY=socks5h://... is proxied, and the report has to say so.
+// ponytail: NO_PROXY is not applied to the ALL_PROXY fallback; the probe host
+// is a fixed public name, so a NO_PROXY hit would only mean the row describes
+// a proxy this one request would have bypassed.
+func proxyFromEnvironment(req *http.Request) (*url.URL, error) {
+	u, err := http.ProxyFromEnvironment(req)
+	if u != nil || err != nil {
+		return u, err
+	}
+	all := os.Getenv("ALL_PROXY")
+	if all == "" {
+		all = os.Getenv("all_proxy")
+	}
+	if all == "" {
+		return nil, nil
+	}
+	// Same tolerance net/http grants HTTP_PROXY: a bare host:port means http.
+	if u, err := url.Parse(all); err == nil && u.Scheme != "" && u.Host != "" {
+		return u, nil
+	}
+	return url.Parse("http://" + all)
+}
+
 // proxyProbe checks egress through the environment-configured proxy: dial the
-// proxy and ask for a CONNECT tunnel to probeHost:443. This is exactly what
-// proxied HTTPS clients do, minus the TLS handshake inside the tunnel.
+// proxy and ask it to tunnel to probeHost:443, by HTTP CONNECT or a SOCKS5
+// handshake. This is exactly what proxied HTTPS clients do, minus the TLS
+// handshake inside the tunnel.
 func (o *netops) proxyProbe(ctx context.Context, _ map[ProbeID]ProbeResult) ProbeResult {
 	var r ProbeResult
 	var proxyURL *url.URL
@@ -719,22 +746,23 @@ func (o *netops) proxyProbe(ctx context.Context, _ map[ProbeID]ProbeResult) Prob
 	}
 	if err != nil {
 		r.Status = StatusFail
-		r.Detail = "bad proxy configuration: HTTPS_PROXY/HTTP_PROXY is not a valid proxy URL"
-		r.Fix = "fix the HTTPS_PROXY/HTTP_PROXY value"
+		r.Detail = "bad proxy configuration: HTTPS_PROXY/HTTP_PROXY/ALL_PROXY is not a valid proxy URL"
+		r.Fix = "fix the HTTPS_PROXY/HTTP_PROXY/ALL_PROXY value"
 		return r
 	}
 	if proxyURL == nil {
 		r.Status = StatusNA
-		r.Detail = "no proxy in environment (HTTPS_PROXY/HTTP_PROXY unset)"
+		r.Detail = "no proxy in environment (HTTPS_PROXY/HTTP_PROXY/ALL_PROXY unset)"
 		return r
 	}
 	if proxyURL.Hostname() == "" || proxyURL.Path != "" || proxyURL.RawQuery != "" || proxyURL.ForceQuery || proxyURL.Fragment != "" {
 		r.Status = StatusFail
 		r.Detail = "bad proxy configuration: proxy URL must have a valid host and no path, query, or fragment"
-		r.Fix = "fix the HTTPS_PROXY/HTTP_PROXY value"
+		r.Fix = "fix the HTTPS_PROXY/HTTP_PROXY/ALL_PROXY value"
 		return r
 	}
-	if proxyURL.Scheme != "http" && proxyURL.Scheme != "https" {
+	socks := proxyURL.Scheme == "socks5" || proxyURL.Scheme == "socks5h"
+	if !socks && proxyURL.Scheme != "http" && proxyURL.Scheme != "https" {
 		r.Status = StatusNA
 		r.Detail = "proxy scheme " + proxyURL.Scheme + " is not supported by this probe"
 		return r
@@ -743,15 +771,18 @@ func (o *netops) proxyProbe(ctx context.Context, _ map[ProbeID]ProbeResult) Prob
 		if _, err := parsePort(port); err != nil {
 			r.Status = StatusFail
 			r.Detail = "bad proxy configuration: " + err.Error()
-			r.Fix = "fix the HTTPS_PROXY/HTTP_PROXY value"
+			r.Fix = "fix the HTTPS_PROXY/HTTP_PROXY/ALL_PROXY value"
 			return r
 		}
 	}
 	addr := proxyURL.Host
 	if proxyURL.Port() == "" {
 		port := "80"
-		if proxyURL.Scheme == "https" {
+		switch {
+		case proxyURL.Scheme == "https":
 			port = "443"
+		case socks:
+			port = "1080"
 		}
 		addr = net.JoinHostPort(proxyURL.Hostname(), port)
 	}
@@ -763,6 +794,9 @@ func (o *netops) proxyProbe(ctx context.Context, _ map[ProbeID]ProbeResult) Prob
 	dl, ok := ctx.Deadline()
 	if !ok {
 		dl = time.Now().Add(ProbeTimeout)
+	}
+	if socks {
+		return o.socks5Probe(ctx, addr, dl, start)
 	}
 	var resp *http.Response
 	auth := false
@@ -831,11 +865,113 @@ func (o *netops) proxyProbe(ctx context.Context, _ map[ProbeID]ProbeResult) Prob
 		}
 		return r
 	}
+	return o.proxyTunnelOK(ctx, conn, addr, rtt)
+}
+
+// proxyTunnelOK builds the PASS result shared by the CONNECT and SOCKS5 paths.
+func (o *netops) proxyTunnelOK(ctx context.Context, conn net.Conn, addr string, rtt time.Duration) ProbeResult {
+	var r ProbeResult
 	src, iface := o.pathIdentity(ctx, conn, nil, 0)
 	r.Status, r.Source, r.Iface = StatusPass, src, iface
 	r.Detail = fmt.Sprintf("proxy %s tunnels to %s:443 in %dms", addr, probeHost, Ms(rtt))
 	applyDialWarnings(&r, rtt)
 	return r
+}
+
+// socks5Probe dials a SOCKS5 proxy and asks it to tunnel to probeHost:443.
+// The hostname travels unresolved (socks5h semantics) for both schemes: the
+// proxy is the side with the DNS view that matters, and resolving locally
+// would only re-test what the DNS row already covers.
+func (o *netops) socks5Probe(ctx context.Context, addr string, dl, start time.Time) ProbeResult {
+	var r ProbeResult
+	conn, err := o.dialContext(ctx, "tcp", addr)
+	if err != nil {
+		r.Status = StatusFail
+		r.Detail = "cannot reach proxy " + addr + ": " + err.Error()
+		r.Fix = "proxy configured but unreachable — check ALL_PROXY and the proxy host"
+		return r
+	}
+	defer conn.Close()
+	// net.Conn reads don't know ctx exists; the deadline is the only leash.
+	if err := conn.SetDeadline(dl); err != nil {
+		r.Status = StatusFail
+		r.Detail = "cannot set proxy deadline: " + err.Error()
+		return r
+	}
+	if err := socks5Connect(conn, probeHost, 443); err != nil {
+		r.Status = StatusFail
+		r.Detail = "SOCKS5 proxy " + addr + ": " + err.Error()
+		r.Fix = "check that ALL_PROXY names a SOCKS5 port and that the proxy allows this destination"
+		return r
+	}
+	return o.proxyTunnelOK(ctx, conn, addr, since(start))
+}
+
+// socks5Connect runs the RFC 1928 no-auth handshake on conn and requests a
+// tunnel to host:port. Credentials are never offered: the SOCKS5
+// username/password exchange (RFC 1929) is cleartext, and this probe already
+// refuses to spend credentials on an unencrypted hop. Every read is a fixed,
+// small size — the replies are attacker-controlled.
+func socks5Connect(conn net.Conn, host string, port int) error {
+	if len(host) > 255 {
+		return errors.New("hostname too long for SOCKS5")
+	}
+	// VER 5, offering exactly one method: 0 (no authentication).
+	if _, err := conn.Write([]byte{5, 1, 0}); err != nil {
+		return fmt.Errorf("greeting failed: %w", err)
+	}
+	hello := make([]byte, 2)
+	if _, err := io.ReadFull(conn, hello); err != nil {
+		return fmt.Errorf("no SOCKS5 greeting reply: %w", err)
+	}
+	if hello[0] != 5 {
+		return fmt.Errorf("not a SOCKS5 proxy (reply version %d) — wrong port or scheme?", hello[0])
+	}
+	if hello[1] != 0 {
+		return errors.New("requires authentication; SOCKS5 credentials travel in cleartext, so this probe does not send them")
+	}
+	// CONNECT, reserved, ATYP 3 (domain name) so the proxy does the lookup.
+	req := append([]byte{5, 1, 0, 3, byte(len(host))}, host...)
+	req = append(req, byte(port>>8), byte(port))
+	if _, err := conn.Write(req); err != nil {
+		return fmt.Errorf("CONNECT failed: %w", err)
+	}
+	reply := make([]byte, 4)
+	if _, err := io.ReadFull(conn, reply); err != nil {
+		return fmt.Errorf("no CONNECT reply: %w", err)
+	}
+	if reply[1] != 0 {
+		return errors.New("refused CONNECT: " + socks5Error(reply[1]))
+	}
+	// Drain the bound address so the conn sits at the tunnel's first byte.
+	var n int
+	switch reply[3] {
+	case 1:
+		n = 4
+	case 4:
+		n = 16
+	case 3:
+		var b [1]byte
+		if _, err := io.ReadFull(conn, b[:]); err != nil {
+			return fmt.Errorf("truncated CONNECT reply: %w", err)
+		}
+		n = int(b[0])
+	default:
+		return fmt.Errorf("bad address type %d in CONNECT reply", reply[3])
+	}
+	if _, err := io.ReadFull(conn, make([]byte, n+2)); err != nil {
+		return fmt.Errorf("truncated CONNECT reply: %w", err)
+	}
+	return nil
+}
+
+// socks5Error names an RFC 1928 reply code.
+func socks5Error(code byte) string {
+	msgs := [...]string{1: "general failure", 2: "not allowed by ruleset", 3: "network unreachable", 4: "host unreachable", 5: "connection refused", 6: "TTL expired", 7: "command not supported", 8: "address type not supported"}
+	if int(code) < len(msgs) && msgs[code] != "" {
+		return msgs[code]
+	}
+	return "reply code " + strconv.Itoa(int(code))
 }
 
 func (o *netops) dnsProbe(host string, litIP net.IP) func(context.Context, map[ProbeID]ProbeResult) ProbeResult {

--- a/internal/diagnostic/checks.go
+++ b/internal/diagnostic/checks.go
@@ -705,13 +705,16 @@ func (o *netops) internetProbe(ctx context.Context, _ map[ProbeID]ProbeResult) P
 // proxyFromEnvironment is http.ProxyFromEnvironment plus ALL_PROXY, which Go
 // ignores but curl, ssh and the SOCKS ecosystem honor — a box whose only proxy
 // setting is ALL_PROXY=socks5h://... is proxied, and the report has to say so.
-// ponytail: NO_PROXY is not applied to the ALL_PROXY fallback; the probe host
-// is a fixed public name, so a NO_PROXY hit would only mean the row describes
-// a proxy this one request would have bypassed.
 func proxyFromEnvironment(req *http.Request) (*url.URL, error) {
 	u, err := http.ProxyFromEnvironment(req)
 	if u != nil || err != nil {
 		return u, err
+	}
+	// net/http already applied NO_PROXY to HTTP(S)_PROXY, so a nil here can
+	// equally mean "exempted" — falling back to ALL_PROXY on that would report
+	// a proxy nothing would use for this host.
+	if noProxyBypasses(req.URL.Hostname()) {
+		return nil, nil
 	}
 	all := os.Getenv("ALL_PROXY")
 	if all == "" {
@@ -725,6 +728,33 @@ func proxyFromEnvironment(req *http.Request) (*url.URL, error) {
 		return u, nil
 	}
 	return url.Parse("http://" + all)
+}
+
+// noProxyBypasses reports whether NO_PROXY exempts host from proxying — the
+// check net/http applies to HTTP(S)_PROXY and this file has to apply itself to
+// the ALL_PROXY fallback.
+// ponytail: suffix and "*" matching only, no IP or CIDR entries; the only host
+// asked about is probeHost, a fixed public name that is never a literal IP.
+func noProxyBypasses(host string) bool {
+	np := os.Getenv("NO_PROXY")
+	if np == "" {
+		np = os.Getenv("no_proxy")
+	}
+	host = strings.ToLower(host)
+	for _, entry := range strings.Split(np, ",") {
+		entry = strings.ToLower(strings.TrimSpace(entry))
+		if entry == "*" {
+			return true
+		}
+		entry = strings.TrimPrefix(entry, ".")
+		if entry == "" {
+			continue
+		}
+		if host == entry || strings.HasSuffix(host, "."+entry) {
+			return true
+		}
+	}
+	return false
 }
 
 // proxyProbe checks egress through the environment-configured proxy: dial the

--- a/internal/diagnostic/checks.go
+++ b/internal/diagnostic/checks.go
@@ -908,10 +908,8 @@ func (o *netops) socks5Probe(ctx context.Context, addr string, dl, start time.Ti
 }
 
 // socks5Connect runs the RFC 1928 no-auth handshake on conn and requests a
-// tunnel to probeHost:443. Credentials are never offered: the SOCKS5
-// username/password exchange (RFC 1929) is cleartext, and this probe already
-// refuses to spend credentials on an unencrypted hop. Every read is a fixed,
-// small size — the replies are attacker-controlled.
+// tunnel to probeHost:443. Every read is a fixed, small size — the replies are
+// attacker-controlled.
 func socks5Connect(conn net.Conn) error {
 	// VER 5, offering exactly one method: 0 (no authentication).
 	if _, err := conn.Write([]byte{5, 1, 0}); err != nil {

--- a/internal/diagnostic/checks.go
+++ b/internal/diagnostic/checks.go
@@ -898,7 +898,7 @@ func (o *netops) socks5Probe(ctx context.Context, addr string, dl, start time.Ti
 		r.Detail = "cannot set proxy deadline: " + err.Error()
 		return r
 	}
-	if err := socks5Connect(conn, probeHost, 443); err != nil {
+	if err := socks5Connect(conn); err != nil {
 		r.Status = StatusFail
 		r.Detail = "SOCKS5 proxy " + addr + ": " + err.Error()
 		r.Fix = "check that ALL_PROXY names a SOCKS5 port and that the proxy allows this destination"
@@ -908,12 +908,11 @@ func (o *netops) socks5Probe(ctx context.Context, addr string, dl, start time.Ti
 }
 
 // socks5Connect runs the RFC 1928 no-auth handshake on conn and requests a
-// tunnel to host:port. Credentials are never offered: the SOCKS5
+// tunnel to probeHost:443. Credentials are never offered: the SOCKS5
 // username/password exchange (RFC 1929) is cleartext, and this probe already
 // refuses to spend credentials on an unencrypted hop. Every read is a fixed,
-// small size — the replies are attacker-controlled. host must be at most 255
-// bytes; the only caller passes the probeHost constant.
-func socks5Connect(conn net.Conn, host string, port int) error {
+// small size — the replies are attacker-controlled.
+func socks5Connect(conn net.Conn) error {
 	// VER 5, offering exactly one method: 0 (no authentication).
 	if _, err := conn.Write([]byte{5, 1, 0}); err != nil {
 		return fmt.Errorf("greeting failed: %w", err)
@@ -929,8 +928,8 @@ func socks5Connect(conn net.Conn, host string, port int) error {
 		return errors.New("requires authentication; SOCKS5 credentials travel in cleartext, so this probe does not send them")
 	}
 	// CONNECT, reserved, ATYP 3 (domain name) so the proxy does the lookup.
-	req := append([]byte{5, 1, 0, 3, byte(len(host))}, host...)
-	req = append(req, byte(port>>8), byte(port))
+	req := append([]byte{5, 1, 0, 3, byte(len(probeHost))}, probeHost...)
+	req = append(req, 1, 187) // port 443, network byte order
 	if _, err := conn.Write(req); err != nil {
 		return fmt.Errorf("CONNECT failed: %w", err)
 	}

--- a/internal/diagnostic/checks.go
+++ b/internal/diagnostic/checks.go
@@ -735,6 +735,8 @@ func proxyFromEnvironment(req *http.Request) (*url.URL, error) {
 // the ALL_PROXY fallback.
 // ponytail: suffix and "*" matching only, no IP or CIDR entries; the only host
 // asked about is probeHost, a fixed public name that is never a literal IP.
+// The day a caller passes a host the user chose, drop this for
+// golang.org/x/net/http/httpproxy, the matcher net/http itself uses.
 func noProxyBypasses(host string) bool {
 	np := os.Getenv("NO_PROXY")
 	if np == "" {

--- a/internal/diagnostic/checks.go
+++ b/internal/diagnostic/checks.go
@@ -809,7 +809,7 @@ func (o *netops) proxyProbe(ctx context.Context, _ map[ProbeID]ProbeResult) Prob
 		if err != nil {
 			r.Status = StatusFail
 			r.Detail = "cannot reach proxy " + addr + ": " + err.Error()
-			r.Fix = "proxy configured but unreachable — check HTTPS_PROXY/HTTP_PROXY and the proxy host"
+			r.Fix = "proxy configured but unreachable — check HTTPS_PROXY/HTTP_PROXY/ALL_PROXY and the proxy host"
 			return r
 		}
 		req := "CONNECT " + probeHost + ":443 HTTP/1.1\r\nHost: " + probeHost + ":443\r\n"
@@ -859,7 +859,7 @@ func (o *netops) proxyProbe(ctx context.Context, _ map[ProbeID]ProbeResult) Prob
 		r.Status = StatusFail
 		r.Detail = "proxy " + addr + " refused CONNECT: " + resp.Status
 		if resp.StatusCode == http.StatusProxyAuthRequired {
-			r.Fix = "proxy requires credentials — set user:pass@host in HTTPS_PROXY"
+			r.Fix = "proxy requires credentials — set user:pass@host in the proxy URL"
 		} else {
 			r.Fix = "proxy reachable but refusing tunnels — check proxy policy"
 		}
@@ -888,7 +888,7 @@ func (o *netops) socks5Probe(ctx context.Context, addr string, dl, start time.Ti
 	if err != nil {
 		r.Status = StatusFail
 		r.Detail = "cannot reach proxy " + addr + ": " + err.Error()
-		r.Fix = "proxy configured but unreachable — check ALL_PROXY and the proxy host"
+		r.Fix = "proxy configured but unreachable — check HTTPS_PROXY/HTTP_PROXY/ALL_PROXY and the proxy host"
 		return r
 	}
 	defer conn.Close()
@@ -901,7 +901,7 @@ func (o *netops) socks5Probe(ctx context.Context, addr string, dl, start time.Ti
 	if err := socks5Connect(conn); err != nil {
 		r.Status = StatusFail
 		r.Detail = "SOCKS5 proxy " + addr + ": " + err.Error()
-		r.Fix = "check that ALL_PROXY names a SOCKS5 port and that the proxy allows this destination"
+		r.Fix = "check that the proxy URL names a SOCKS5 port and that the proxy allows this destination"
 		return r
 	}
 	return o.proxyTunnelOK(ctx, conn, addr, since(start))

--- a/internal/diagnostic/checks_extra_test.go
+++ b/internal/diagnostic/checks_extra_test.go
@@ -334,7 +334,6 @@ func TestProxyProbeSocks5Failures(t *testing.T) {
 		want  string
 	}{
 		{"auth demanded", []byte{5, 2}, "cleartext"},
-		{"no acceptable method", []byte{5, 255}, "cleartext"},
 		{"refused", []byte{5, 0, 5, 5, 0, 1, 0, 0, 0, 0, 0, 0}, "connection refused"},
 		{"unknown reply code", []byte{5, 0, 5, 99, 0, 1, 0, 0, 0, 0, 0, 0}, "reply code 99"},
 		{"not a SOCKS port", []byte("HTTP/1.1 400 Bad Request\r\n"), "not a SOCKS5 proxy"},

--- a/internal/diagnostic/checks_extra_test.go
+++ b/internal/diagnostic/checks_extra_test.go
@@ -391,13 +391,6 @@ func TestProxyFromEnvironmentAllProxy(t *testing.T) {
 			t.Errorf("proxyFromEnvironment = %v, %v; want http://proxy.corp:3128", u, err)
 		}
 	})
-	t.Run("unset", func(t *testing.T) {
-		t.Setenv("ALL_PROXY", "")
-		t.Setenv("all_proxy", "")
-		if u, err := proxyFromEnvironment(req); u != nil || err != nil {
-			t.Errorf("proxyFromEnvironment = %v, %v; want no proxy", u, err)
-		}
-	})
 }
 
 func TestProxyProbeUnreachable(t *testing.T) {

--- a/internal/diagnostic/checks_extra_test.go
+++ b/internal/diagnostic/checks_extra_test.go
@@ -335,6 +335,7 @@ func TestProxyProbeSocks5Failures(t *testing.T) {
 	}{
 		{"auth demanded", []byte{5, 2}, "cleartext"},
 		{"refused", []byte{5, 0, 5, 5, 0, 1, 0, 0, 0, 0, 0, 0}, "connection refused"},
+		{"no domain names", []byte{5, 0, 5, 8, 0, 1, 0, 0, 0, 0, 0, 0}, "address type not supported"},
 		{"unknown reply code", []byte{5, 0, 5, 99, 0, 1, 0, 0, 0, 0, 0, 0}, "reply code 99"},
 		{"not a SOCKS port", []byte("HTTP/1.1 400 Bad Request\r\n"), "not a SOCKS5 proxy"},
 		{"truncated", []byte{5, 0, 5, 0, 0, 1}, "truncated"},

--- a/internal/diagnostic/checks_extra_test.go
+++ b/internal/diagnostic/checks_extra_test.go
@@ -262,6 +262,7 @@ func (c *scriptConn) Read(p []byte) (int, error)         { return c.r.Read(p) }
 func (c *scriptConn) Write(p []byte) (int, error)        { return c.w.Write(p) }
 func (*scriptConn) SetReadDeadline(time.Time) error      { return nil }
 func (c *scriptConn) SetWriteDeadline(d time.Time) error { c.writeDeadline = d; return nil }
+func (c *scriptConn) SetDeadline(d time.Time) error      { c.writeDeadline = d; return nil }
 
 func proxyOps(proxy string, dial func(context.Context, string, string) (net.Conn, error)) *netops {
 	return &netops{
@@ -282,15 +283,122 @@ func TestProxyProbeNoProxyIsNA(t *testing.T) {
 	}
 }
 
-func TestProxyProbeSocksIsNA(t *testing.T) {
-	ops := proxyOps("socks5://proxy.corp", func(context.Context, string, string) (net.Conn, error) {
-		t.Fatal("SOCKS proxy must not receive an HTTP CONNECT probe")
+func TestProxyProbeUnknownSchemeIsNA(t *testing.T) {
+	ops := proxyOps("socks4://proxy.corp", func(context.Context, string, string) (net.Conn, error) {
+		t.Fatal("an unsupported proxy scheme must not be dialed")
 		return nil, nil
 	})
 	r := ops.proxyProbe(context.Background(), nil)
-	if r.Status != StatusNA || !strings.Contains(r.Detail, "socks5") {
-		t.Errorf("SOCKS proxy = %+v, want N/A", r)
+	if r.Status != StatusNA || !strings.Contains(r.Detail, "socks4") {
+		t.Errorf("SOCKS4 proxy = %+v, want N/A", r)
 	}
+}
+
+// socks5Reply is a granted CONNECT: greeting picks no-auth, then reply code 0
+// with a bound IPv4 address.
+var socks5Reply = string([]byte{5, 0, 5, 0, 0, 1, 0, 0, 0, 0, 0, 0})
+
+// A SOCKS5 proxy (ALL_PROXY's usual scheme) is probed with a real handshake,
+// and the destination goes over the wire as a name for the proxy to resolve.
+func TestProxyProbeSocks5(t *testing.T) {
+	for _, scheme := range []string{"socks5", "socks5h"} {
+		t.Run(scheme, func(t *testing.T) {
+			conn := &scriptConn{r: strings.NewReader(socks5Reply)}
+			var dialed string
+			ops := proxyOps(scheme+"://proxy.corp", func(_ context.Context, _, addr string) (net.Conn, error) {
+				dialed = addr
+				return conn, nil
+			})
+			r := ops.proxyProbe(context.Background(), nil)
+			if r.Status != StatusPass || !strings.Contains(r.Detail, "proxy proxy.corp:1080 tunnels") {
+				t.Errorf("granted SOCKS5 CONNECT = %+v, want PASS", r)
+			}
+			if dialed != "proxy.corp:1080" {
+				t.Errorf("dialed %q, want proxy.corp:1080 (default SOCKS port)", dialed)
+			}
+			want := string([]byte{5, 1, 0, 5, 1, 0, 3, byte(len(probeHost))}) + probeHost + string([]byte{1, 187})
+			if conn.w.String() != want {
+				t.Errorf("wire bytes = %q, want %q", conn.w.String(), want)
+			}
+			if conn.writeDeadline.IsZero() {
+				t.Error("deadline is zero, want the probe budget as a leash")
+			}
+		})
+	}
+}
+
+func TestProxyProbeSocks5Failures(t *testing.T) {
+	cases := []struct {
+		name  string
+		reply []byte
+		want  string
+	}{
+		{"auth demanded", []byte{5, 2}, "cleartext"},
+		{"no acceptable method", []byte{5, 255}, "cleartext"},
+		{"refused", []byte{5, 0, 5, 5, 0, 1, 0, 0, 0, 0, 0, 0}, "connection refused"},
+		{"unknown reply code", []byte{5, 0, 5, 99, 0, 1, 0, 0, 0, 0, 0, 0}, "reply code 99"},
+		{"not a SOCKS port", []byte("HTTP/1.1 400 Bad Request\r\n"), "not a SOCKS5 proxy"},
+		{"truncated", []byte{5, 0, 5, 0, 0, 1}, "truncated"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			conn := &scriptConn{r: strings.NewReader(string(c.reply))}
+			ops := proxyOps("socks5h://user:pw@proxy.corp:1080", func(context.Context, string, string) (net.Conn, error) {
+				return conn, nil
+			})
+			r := ops.proxyProbe(context.Background(), nil)
+			if r.Status != StatusFail || !strings.Contains(r.Detail, c.want) {
+				t.Errorf("SOCKS5 %s = %+v, want FAIL mentioning %q", c.name, r, c.want)
+			}
+			if strings.Contains(conn.w.String(), "pw") {
+				t.Errorf("SOCKS5 handshake leaked credentials: %q", conn.w.String())
+			}
+		})
+	}
+}
+
+func TestProxyProbeSocks5Unreachable(t *testing.T) {
+	ops := proxyOps("socks5h://proxy.corp:1080", func(context.Context, string, string) (net.Conn, error) {
+		return nil, errors.New("connection refused")
+	})
+	r := ops.proxyProbe(context.Background(), nil)
+	if r.Status != StatusFail || !strings.Contains(r.Detail, "cannot reach proxy") {
+		t.Errorf("unreachable SOCKS5 proxy = %+v, want FAIL", r)
+	}
+}
+
+// Go's own ProxyFromEnvironment ignores ALL_PROXY; netdoc must not, or a box
+// proxied only through ALL_PROXY reads as having no proxy at all.
+func TestProxyFromEnvironmentAllProxy(t *testing.T) {
+	req := &http.Request{URL: &url.URL{Scheme: "https", Host: probeHost}}
+	if u, err := http.ProxyFromEnvironment(req); u != nil || err != nil {
+		t.Skipf("test environment already has HTTP(S)_PROXY set (%v, %v)", u, err)
+	}
+	for _, name := range []string{"ALL_PROXY", "all_proxy"} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("ALL_PROXY", "")
+			t.Setenv("all_proxy", "")
+			t.Setenv(name, "socks5h://proxy.corp:1080")
+			u, err := proxyFromEnvironment(req)
+			if err != nil || u == nil || u.Scheme != "socks5h" || u.Host != "proxy.corp:1080" {
+				t.Errorf("proxyFromEnvironment = %v, %v; want socks5h://proxy.corp:1080", u, err)
+			}
+		})
+	}
+	t.Run("bare host defaults to http", func(t *testing.T) {
+		t.Setenv("ALL_PROXY", "proxy.corp:3128")
+		u, err := proxyFromEnvironment(req)
+		if err != nil || u == nil || u.Scheme != "http" || u.Host != "proxy.corp:3128" {
+			t.Errorf("proxyFromEnvironment = %v, %v; want http://proxy.corp:3128", u, err)
+		}
+	})
+	t.Run("unset", func(t *testing.T) {
+		t.Setenv("ALL_PROXY", "")
+		t.Setenv("all_proxy", "")
+		if u, err := proxyFromEnvironment(req); u != nil || err != nil {
+			t.Errorf("proxyFromEnvironment = %v, %v; want no proxy", u, err)
+		}
+	})
 }
 
 func TestProxyProbeUnreachable(t *testing.T) {

--- a/internal/diagnostic/checks_extra_test.go
+++ b/internal/diagnostic/checks_extra_test.go
@@ -385,6 +385,24 @@ func TestProxyFromEnvironmentAllProxy(t *testing.T) {
 			}
 		})
 	}
+	// A NO_PROXY hit is why net/http returned nil; falling back to ALL_PROXY
+	// there would report a proxy this host would never go through.
+	for _, np := range []string{"*", "gstatic.com", ".gstatic.com", "connectivitycheck.gstatic.com"} {
+		t.Run("NO_PROXY="+np, func(t *testing.T) {
+			t.Setenv("ALL_PROXY", "socks5h://proxy.corp:1080")
+			t.Setenv("NO_PROXY", np)
+			if u, err := proxyFromEnvironment(req); u != nil || err != nil {
+				t.Errorf("proxyFromEnvironment = %v, %v; want nil, nil", u, err)
+			}
+		})
+	}
+	t.Run("NO_PROXY miss still falls back", func(t *testing.T) {
+		t.Setenv("ALL_PROXY", "socks5h://proxy.corp:1080")
+		t.Setenv("NO_PROXY", "example.com,notgstatic.com")
+		if u, err := proxyFromEnvironment(req); err != nil || u == nil || u.Host != "proxy.corp:1080" {
+			t.Errorf("proxyFromEnvironment = %v, %v; want socks5h://proxy.corp:1080", u, err)
+		}
+	})
 	t.Run("bare host defaults to http", func(t *testing.T) {
 		t.Setenv("ALL_PROXY", "proxy.corp:3128")
 		u, err := proxyFromEnvironment(req)

--- a/internal/diagnostic/diagnosis.go
+++ b/internal/diagnostic/diagnosis.go
@@ -77,7 +77,7 @@ func Diagnose(t *Target, order []ProbeID, res map[ProbeID]ProbeResult) (string, 
 		case warn(ProbeDNSPublic) && functional(res[ProbeDNS].Status):
 			return "Online, but system DNS and public DNS disagree — split DNS or filtering may be intentional (see the DNS rows).", gv
 		case ip && dn && prxDown:
-			return "Online directly — but the configured environment proxy check failed, so apps that honor HTTP(S)_PROXY will fail (see the proxy row).", VerdictDegraded
+			return "Online directly — but the configured environment proxy check failed, so apps that use the proxy will fail (see the proxy row).", VerdictDegraded
 		case ip && dn:
 			return "Online — direct TCP egress and DNS both work.", gv
 		case warn(ProbeInternet) && res[ProbeInternet].downgraded && dn && prx:
@@ -151,7 +151,7 @@ func Diagnose(t *Target, order []ProbeID, res map[ProbeID]ProbeResult) (string, 
 	case fail(ProbeInternet) || (warn(ProbeInternet) && res[ProbeInternet].downgraded):
 		return "The target works but direct internet egress is blocked (proxy-only or filtered network?).", VerdictDegraded
 	case prxDown && directOK():
-		return "The target and direct egress work, but the configured environment proxy check failed — apps that honor HTTP(S)_PROXY will fail (see the proxy row).", VerdictDegraded
+		return "The target and direct egress work, but the configured environment proxy check failed — apps that use the proxy will fail (see the proxy row).", VerdictDegraded
 	case warn(ProbeInternet):
 		return "The target works but direct internet egress is degraded (see the ! row for details).", VerdictDegraded
 	case warn(ProbeDNSPublic):

--- a/internal/diagnostic/diagnosis_test.go
+++ b/internal/diagnostic/diagnosis_test.go
@@ -194,7 +194,7 @@ func TestVerdict(t *testing.T) {
 			ProbeTargetTCP: {Status: StatusWarn},
 		}, VerdictDegraded},
 		// The target and direct egress both work; only the configured proxy
-		// check failed. Apps that honor HTTP(S)_PROXY will still fail, so
+		// check failed. Apps that use the proxy will still fail, so
 		// this can't be a clean pass.
 		{"target fine, configured proxy broken", tg, targetOrder, map[ProbeID]ProbeResult{
 			ProbeProxy: {Status: StatusFail},


### PR DESCRIPTION
Fixes #11.

## User-visible effect

`netdoc` reads `ALL_PROXY`/`all_proxy` when `HTTPS_PROXY`/`HTTP_PROXY` are unset (Go's `http.ProxyFromEnvironment` ignores it; curl and ssh don't), and the **Internet (env proxy)** row now probes `socks5`/`socks5h` proxies with a real RFC 1928 handshake to `connectivitycheck.gstatic.com:443` instead of reporting `proxy scheme socks5h is not supported by this probe`.

Before, a SOCKS-only box reported "no proxy in environment", so the verdict blamed the network for what was really a proxy-only path. Now that row passes and the diagnosis says so ("Online via the environment proxy — direct egress is blocked").

Default port for a SOCKS URL without one is 1080. The destination goes over the wire as a name (ATYP 3) for both schemes, so the proxy resolves it — `socks5h` semantics; a local lookup would only re-test what the DNS row covers.

Credentials are never offered: SOCKS5 user/pass (RFC 1929) is cleartext, matching the existing refusal to send Basic auth to an `http://` proxy. A proxy demanding auth fails the row with that as the reason.

Unchanged by design: the direct-egress, TCP, TLS and HTTP rows still bypass proxies. Those rows measure the direct path on purpose, and `downgradeEgress` already uses a working proxy row to soften the direct-egress failure.

`NO_PROXY` is not applied to the `ALL_PROXY` fallback (noted with a `ponytail:` comment): the probe host is a fixed public name, so a `NO_PROXY` hit would only mean the row describes a proxy this one request would have bypassed.

## Validation

Full gate, all green:

`go vet ./...`, `CGO_ENABLED=0 go build ./...`, `go test ./...`, `go test -tags integration ./internal/diagnostic`, `go test -race ./...`, `go test -fuzz=FuzzSanitize -fuzztime=10s ./internal/textsafe`, `golangci-lint run ./...` (0 issues), `govulncheck ./...` (no vulnerabilities), `goreleaser check`, plus `GOOS=darwin go build ./...` and `GOOS=windows go build ./...`.

New tests cover the handshake wire bytes, both schemes, the default port, auth demanded / no acceptable method / refused / unknown reply code / non-SOCKS port / truncated reply, an unreachable proxy, and the `ALL_PROXY` lookup (both cases, bare `host:port`, unset). No platform-specific behavior in this change; the probe is the same code on all three OSes.