### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/internal/diagnostic/route_cause_linux.go
+++ b/internal/diagnostic/route_cause_linux.go
@@ -82,8 +82,8 @@ func parseIPv6DefaultRoutes(raw []byte) []defaultRouteState {
 		if err != nil || flags&routeFlagUp == 0 {
 			continue
 		}
-		metric, err := strconv.ParseUint(fields[5], 16, 32)
-		if err != nil || metric > uint64(^uint(0)>>1) {
+		metric, err := strconv.ParseInt(fields[5], 16, 32)
+		if err != nil || metric < 0 {
 			continue
 		}
 		gatewayRaw, err := hex.DecodeString(fields[4])


### PR DESCRIPTION
Potential fix for [https://github.com/heymaikol/network-doctor/security/code-scanning/2](https://github.com/heymaikol/network-doctor/security/code-scanning/2)

Use a parse width that matches the destination safety contract and perform a constant-bound check that CodeQL can verify.

Best fix here: in `parseIPv6DefaultRoutes` (around lines 85–97), parse `metric` as a **signed 32-bit** integer (`strconv.ParseInt(..., 32)`), reject negative values, and then convert to `int`. This preserves behavior for valid non-negative metrics while removing unsigned-to-platform-int truncation risk and satisfying static analysis with explicit constant sizing.

Changes needed in `internal/diagnostic/route_cause_linux.go`:
- Replace `strconv.ParseUint(fields[5], 16, 32)` with `strconv.ParseInt(fields[5], 16, 32)`.
- Replace the existing dynamic upper-bound check with `metric < 0` check (ParseInt with 32 bits already enforces max `math.MaxInt32`).
- Keep final assignment as `metric: int(metric)` (safe after parse/check).
- No new imports required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
