### PR TITLE
Vim Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ The TUI saves up to 50 recent targets between sessions in `$XDG_CONFIG_HOME/netd
 | Key | Action |
 |-----|--------|
 | `↑`/`↓` (`k`/`j`) | select a probe row, or a device in the network map |
+| `home`/`end` | jump to the first or last probe row, or device in the network map |
 | `v` | run a LAN scan and show a network map of the local private `/24` (unprivileged `nmap`) |
 | `enter` | set the selected map device as the new target, or open the current tool job's output |
 | `/` (viewer) | filter the viewer to matching lines (`enter` commits, `esc` clears it, a second `esc` leaves) |
@@ -243,6 +244,38 @@ The TUI saves up to 50 recent targets between sessions in `$XDG_CONFIG_HOME/netd
 | `y` / `w` | yank / write (copy / save locally) a reviewable report of the chain plus every tool job |
 | `?` | full-screen key cheatsheet; any key closes it |
 | `q` | quit (cancels running jobs first, then exits) |
+
+### Key bindings
+
+Every key above is an *action*, and both the preset and the individual keys are yours to change. `--keys vim` switches to the vim preset for one run:
+
+| Action | vim keys | still bound |
+|--------|----------|-------------|
+| first / last row | `gg` / `G` | `home`/`end` |
+| page up / down (viewer) | `ctrl+b` / `ctrl+f` | `pgup`/`pgdn` |
+| half page up / down (viewer) | `ctrl+u` / `ctrl+d` | — |
+
+The preset adds motions rather than replacing keys: `j`/`k`, `/`, and `y` were already the vim spelling of themselves, and `home`/`end`/`pgup`/`pgdn` keep working, so a shared terminal stays usable for whoever sits down at it.
+
+To make it permanent, or to move individual keys, write `~/.netdocrc` (or `netdoc/config.yaml` under the config directory that already holds `history` — the dotfile wins if both exist):
+
+```yaml
+keys: vim            # base preset: default (the omitted value) or vim
+
+bindings:            # per-action overrides, applied on top of the preset
+  quit: [q, Q]       # the complete key list for that action
+  restart: [ctrl+r]
+  top: ["g g"]       # a chord: its keys separated by spaces
+  network-map: []    # an empty list unbinds the action outright
+```
+
+`--keys` overrides the file's `keys:` for one run; your `bindings:` still apply on top of it. `--no-config` ignores the file entirely, which is the way back in if a keymap locks you out. netdoc only ever reads the file — it is never created, repaired, or rewritten for you.
+
+Action names are the ones the `?` cheatsheet lists: `up`, `down`, `top`, `bottom`, `page-up`, `page-down`, `half-page-up`, `half-page-down`, `open`, `filter`, `copy`, `save`, `switch-job`, `cancel-job`, `network-map`, `restart`, `ssh`, `clear-filter`, `back`, `help`, `quit`. Key names are the ones your terminal sends — a single character (`q`, `G`, `?`), or a named key in lower case (`enter`, `esc`, `tab`, `space`, `home`, `end`, `pgup`, `pgdown`, `up`, `down`, `left`, `right`, `delete`, `insert`, `f1`–`f12`, `ctrl+a`, `shift+tab`, …).
+
+The cheatsheet and the contextual help bar are generated from your bindings, so they always show the keys that actually run, and an action you unbind stops being advertised. Rebinding covers the check list and the output viewer; the restart prompt, SSH form, filter line, and the tool confirm gate keep fixed keys, since every printable key there belongs to what you are typing. Drill-down tool hotkeys are fixed too — a binding that would shadow one is rejected rather than quietly breaking that tool on the targets that offer it.
+
+A config netdoc cannot use is reported, never fatal: it prints every problem to stderr, says so in the TUI, and runs on the built-in keys. `netdoc` is usually started *during* an outage, so refusing to start over a stale dotfile is the one response that helps nobody.
 
 ## Drill-down tools
 

--- a/README.md
+++ b/README.md
@@ -461,7 +461,26 @@ Race, fuzz, and network-namespace checks run only on Linux in CI. The
 `netns_integration` tests skip themselves on a host without unprivileged user
 namespaces; they never need root. That gate keeps `-v` because a skipped run and
 a real one both print just `ok` otherwise, and `-count=1` because a cached
-result would not have exercised any namespace at all.
+result would not have exercised any namespace at all. Off Linux those tests are
+absent rather than skipped — they read the backend's own Linux internals to
+prove the host was left alone — so the step passes there without exercising a
+namespace.
+
+Two steps therefore mean less than they appear to on macOS and Windows, and one
+of them looks like a failure. `golangci-lint` analyses a single build
+configuration, and CI lints on Linux: run it from another platform and the
+`unused` linter reports every helper that only Linux-tagged code calls — around
+forty in `internal/simulation`, none of them real. To reproduce CI's result,
+build the linter for your own machine and point it at the Linux configuration:
+
+```sh
+tools=$(mktemp -d)
+GOBIN=$tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+GOOS=linux $tools/golangci-lint run ./...
+```
+
+`GOOS=linux go run …` does not work for this: it cross-builds the linter itself
+and then cannot execute it.
 
 ## Testing Network Doctor against broken networks
 

--- a/README.md
+++ b/README.md
@@ -231,31 +231,34 @@ The TUI saves up to 50 recent targets between sessions in `$XDG_CONFIG_HOME/netd
 | Key | Action |
 |-----|--------|
 | `↑`/`↓` (`k`/`j`) | select a probe row, or a device in the network map |
-| `home`/`end` | jump to the first or last probe row, or device in the network map |
+| `home`/`end` (`gg`/`G`) | jump to the first or last probe row, or device in the network map |
 | `v` | run a LAN scan and show a network map of the local private `/24` (unprivileged `nmap`) |
 | `enter` | set the selected map device as the new target, or open the current tool job's output |
 | `/` (viewer) | filter the viewer to matching lines (`enter` commits, `esc` clears it, a second `esc` leaves) |
-| `home`/`end`, `pgup`/`pgdn` (viewer) | jump to top/bottom (`end` re-enables follow) or page through the output |
+| `home`/`end` (`gg`/`G`), `pgup`/`pgdn` (viewer) | jump to top/bottom (`end` and `G` re-enable follow) or page through the output |
 | `y` / `w` (viewer) | copy / save the viewer's retained output (up to 5,000 lines; respects its filter) |
 | `r` | restart with a new target |
 | `S` | SSH login — a form for username, key, and password, then hands the terminal to `ssh` (hinted only once the SSH banner check passes, but usable against any target) |
 | `tab` | switch between running tool jobs |
 | `esc` | cancel the focused job only (`tab` picks which); `q` is the stop-everything path |
 | `y` / `w` | yank / write (copy / save locally) a reviewable report of the chain plus every tool job |
-| `?` | full-screen key cheatsheet; any key closes it |
+| `?` | full-screen key cheatsheet, from the check list, the network map, or a tool's full output; it scrolls when your terminal is too short for it, and any key that isn't a motion closes it |
 | `q` | quit (cancels running jobs first, then exits) |
 
 ### Key bindings
 
-Every key above is an *action*, and both the preset and the individual keys are yours to change. `--keys vim` switches to the vim preset for one run:
+Every key above is an *action*, and both the preset and the individual keys are yours to change.
+
+`gg` and `G` need no preset and no config: they jump to the top and bottom of whatever you are looking at — the check list, the network map, and the full output of any tool, `route table` and `open sockets` included. They are in the default keymap because they cost a non-vim user nothing, both keys having previously done nothing at all, and because reaching the top of a long route table should not require a config file.
+
+`--keys vim` adds the motions that would have cost something:
 
 | Action | vim keys | still bound |
 |--------|----------|-------------|
-| first / last row | `gg` / `G` | `home`/`end` |
 | page up / down (viewer) | `ctrl+b` / `ctrl+f` | `pgup`/`pgdn` |
 | half page up / down (viewer) | `ctrl+u` / `ctrl+d` | — |
 
-The preset adds motions rather than replacing keys: `j`/`k`, `/`, and `y` were already the vim spelling of themselves, and `home`/`end`/`pgup`/`pgdn` keep working, so a shared terminal stays usable for whoever sits down at it.
+The preset adds motions rather than replacing keys: `j`/`k`, `/`, and `y` were already the vim spelling of themselves, and `home`/`end`/`pgup`/`pgdn` keep working, so a shared terminal stays usable for whoever sits down at it. What it does change is billing: `gg`/`G` are listed ahead of `home`/`end` in the help bar, so the preset says out loud that it is on.
 
 To make it permanent, or to move individual keys, write `~/.netdocrc` (or `netdoc/config.yaml` under the config directory that already holds `history` — the dotfile wins if both exist):
 
@@ -303,8 +306,21 @@ Output viewer
   tab            switch job
   esc            clear the filter, or back when none is set
   q              back
+  ?              full-screen key cheatsheet
 
 any key close
+```
+
+The sheet is exhaustive, which makes it taller than a short terminal, so it scrolls with the same motions that scroll output — and only those keys; everything else still closes it:
+
+```
+  ctrl+r         restart with a new target
+  ?              full-screen key cheatsheet
+  q/Q            quit
+  i              run route table
+  s              run open sockets
+
+1–16 of 32  ·  ↑/↓ scroll  ·  gg/G top/bottom  ·  any other key close
 ```
 
 `network-map` has no row because the file unbound it, and the help bar drops its chip to match:

--- a/README.md
+++ b/README.md
@@ -249,18 +249,9 @@ The TUI saves up to 50 recent targets between sessions in `$XDG_CONFIG_HOME/netd
 
 Every key above is an *action*, and both the preset and the individual keys are yours to change.
 
-`gg` and `G` need no preset and no config: they jump to the top and bottom of whatever you are looking at — the check list, the network map, and the full output of any tool, `route table` and `open sockets` included. They are in the default keymap because they cost a non-vim user nothing, both keys having previously done nothing at all, and because reaching the top of a long route table should not require a config file.
+`gg` and `G` jump to the top and bottom of whatever is on screen — the check list, the network map, and any tool's full output — with no configuration. `--keys vim` adds `ctrl+b`/`ctrl+f` (page) and `ctrl+u`/`ctrl+d` (half page) in the viewer, and lists `gg`/`G` ahead of `home`/`end` in the help bar. `home`/`end`/`pgup`/`pgdn` work under both.
 
-`--keys vim` adds the motions that would have cost something:
-
-| Action | vim keys | still bound |
-|--------|----------|-------------|
-| page up / down (viewer) | `ctrl+b` / `ctrl+f` | `pgup`/`pgdn` |
-| half page up / down (viewer) | `ctrl+u` / `ctrl+d` | — |
-
-The preset adds motions rather than replacing keys: `j`/`k`, `/`, and `y` were already the vim spelling of themselves, and `home`/`end`/`pgup`/`pgdn` keep working, so a shared terminal stays usable for whoever sits down at it. What it does change is billing: `gg`/`G` are listed ahead of `home`/`end` in the help bar, so the preset says out loud that it is on.
-
-To make it permanent, or to move individual keys, write `~/.netdocrc` (or `netdoc/config.yaml` under the config directory that already holds `history` — the dotfile wins if both exist):
+For a permanent change, or to move individual keys, write `~/.netdocrc` (or `netdoc/config.yaml` under the config directory that holds `history`; the dotfile wins if both exist):
 
 ```yaml
 keys: vim            # base preset: default (the omitted value) or vim
@@ -272,7 +263,11 @@ bindings:            # per-action overrides, applied on top of the preset
   network-map: []    # an empty list unbinds the action outright
 ```
 
-`?` shows what that file actually did. The cheatsheet is generated from your bindings rather than written by hand, so it is also how you check them — here it is with exactly the config above in effect, on a run started with no target (so the toolbox lists only the two tools that need none):
+`--keys` overrides the file's `keys:` for one run, and your `bindings:` still apply on top. `--no-config` ignores the file. netdoc only ever reads it.
+
+Action names are the ones `?` lists: `up`, `down`, `top`, `bottom`, `page-up`, `page-down`, `half-page-up`, `half-page-down`, `open`, `filter`, `copy`, `save`, `switch-job`, `cancel-job`, `network-map`, `restart`, `ssh`, `clear-filter`, `back`, `help`, `quit`. Key names are the ones your terminal sends — a single character (`q`, `G`, `?`), or a named key in lower case (`enter`, `esc`, `tab`, `space`, `home`, `end`, `pgup`, `pgdown`, `up`, `down`, `left`, `right`, `delete`, `insert`, `f1`–`f12`, `ctrl+a`, `shift+tab`, …).
+
+`?` lists the keys that are actually bound, so it doubles as a check on the file. With the config above in effect, on a run started with no target:
 
 ```
 Keys
@@ -311,45 +306,9 @@ Output viewer
 any key close
 ```
 
-The sheet is exhaustive, which makes it taller than a short terminal, so it scrolls with the same motions that scroll output — and only those keys; everything else still closes it:
+Rebinding covers the check list and the output viewer. The restart prompt, SSH form, filter line, and tool confirm gate keep fixed keys, as do drill-down tool hotkeys — a binding that would shadow one is rejected.
 
-```
-  ctrl+r         restart with a new target
-  ?              full-screen key cheatsheet
-  q/Q            quit
-  i              run route table
-  s              run open sockets
-
-1–16 of 32  ·  ↑/↓ scroll  ·  gg/G top/bottom  ·  any other key close
-```
-
-`network-map` has no row because the file unbound it, and the help bar drops its chip to match:
-
-```
-Dig deeper  [i] route table  ·  [s] open sockets  ·  [S] SSH login — needs a target
-
-ctrl+r run the checks  ·  letter runs that tool  ·  ? help  ·  q/Q quit
-```
-
-`--keys` overrides the file's `keys:` for one run; your `bindings:` still apply on top of it. `--no-config` ignores the file entirely, which is the way back in if a keymap locks you out. netdoc only ever reads the file — it is never created, repaired, or rewritten for you.
-
-Action names are the ones the `?` cheatsheet lists: `up`, `down`, `top`, `bottom`, `page-up`, `page-down`, `half-page-up`, `half-page-down`, `open`, `filter`, `copy`, `save`, `switch-job`, `cancel-job`, `network-map`, `restart`, `ssh`, `clear-filter`, `back`, `help`, `quit`. Key names are the ones your terminal sends — a single character (`q`, `G`, `?`), or a named key in lower case (`enter`, `esc`, `tab`, `space`, `home`, `end`, `pgup`, `pgdown`, `up`, `down`, `left`, `right`, `delete`, `insert`, `f1`–`f12`, `ctrl+a`, `shift+tab`, …).
-
-The cheatsheet and the contextual help bar are generated from your bindings, so they always show the keys that actually run, and an action you unbind stops being advertised. Rebinding covers the check list and the output viewer; the restart prompt, SSH form, filter line, and the tool confirm gate keep fixed keys, since every printable key there belongs to what you are typing. Drill-down tool hotkeys are fixed too — a binding that would shadow one is rejected rather than quietly breaking that tool on the targets that offer it.
-
-A config netdoc cannot use is reported, never fatal: it prints every problem to stderr, says so in the TUI, and runs on the built-in keys. `netdoc` is usually started *during* an outage, so refusing to start over a stale dotfile is the one response that helps nobody. A file with `quti:` where you meant `quit:` gets you this, and a working keymap:
-
-```
-netdoc: /home/you/.netdocrc: unknown action "quti"
-```
-
-```
-✗ .netdocrc: unknown action "quti" — using the built-in keys
-
-r run the checks  ·  v network map  ·  letter runs that tool  ·  ? help  ·  q quit
-```
-
-The stderr line is still on your terminal after netdoc exits, which is where the keymap gets fixed; the notice is what says so while the alt screen has the scrollback. Every problem in the file is listed, not just the first, and none of the bindings are applied — a half-applied keymap is a puzzle with nothing on screen to explain it.
+A config netdoc cannot use is reported on stderr and in the TUI, and the run continues on the built-in keys. Every problem in the file is listed, and none of the bindings are applied.
 
 ## Drill-down tools
 
@@ -536,25 +495,19 @@ Race, fuzz, and network-namespace checks run only on Linux in CI. The
 namespaces; they never need root. That gate keeps `-v` because a skipped run and
 a real one both print just `ok` otherwise, and `-count=1` because a cached
 result would not have exercised any namespace at all. Off Linux those tests are
-absent rather than skipped — they read the backend's own Linux internals to
-prove the host was left alone — so the step passes there without exercising a
-namespace.
+absent, so the step passes without exercising a namespace.
 
-Two steps therefore mean less than they appear to on macOS and Windows, and one
-of them looks like a failure. `golangci-lint` analyses a single build
-configuration, and CI lints on Linux: run it from another platform and the
-`unused` linter reports every helper that only Linux-tagged code calls — around
-forty in `internal/simulation`, none of them real. To reproduce CI's result,
-build the linter for your own machine and point it at the Linux configuration:
+`golangci-lint` analyses one build configuration and CI lints on Linux, so
+running it on macOS or Windows reports the helpers only Linux-tagged code calls
+as `unused` — around forty in `internal/simulation`, none of them real. Point a
+host-built linter at the Linux configuration to get CI's result (`GOOS=linux go
+run …` cross-builds the linter itself and then cannot execute it):
 
 ```sh
 tools=$(mktemp -d)
 GOBIN=$tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 GOOS=linux $tools/golangci-lint run ./...
 ```
-
-`GOOS=linux go run …` does not work for this: it cross-builds the linter itself
-and then cannot execute it.
 
 ## Testing Network Doctor against broken networks
 

--- a/README.md
+++ b/README.md
@@ -265,8 +265,54 @@ keys: vim            # base preset: default (the omitted value) or vim
 bindings:            # per-action overrides, applied on top of the preset
   quit: [q, Q]       # the complete key list for that action
   restart: [ctrl+r]
-  top: ["g g"]       # a chord: its keys separated by spaces
+  copy: ["y y", Y]   # a chord: its keys separated by spaces
   network-map: []    # an empty list unbinds the action outright
+```
+
+`?` shows what that file actually did. The cheatsheet is generated from your bindings rather than written by hand, so it is also how you check them — here it is with exactly the config above in effect, on a run started with no target (so the toolbox lists only the two tools that need none):
+
+```
+Keys
+  ↑/k            previous check — or device on the network map
+  ↓/j            next check — or device on the network map
+  gg/home        first check — or device on the network map
+  G/end          last check — or device on the network map
+  enter          full output — or set target on the network map
+  yy/Y           copy selected portal URL, otherwise report
+  w              save report
+  tab            switch job
+  esc            cancel the focused job
+  ctrl+r         restart with a new target
+  ?              full-screen key cheatsheet
+  q/Q            quit
+  i              run route table
+  s              run open sockets
+
+Output viewer
+  ↑/k            scroll up
+  ↓/j            scroll down
+  gg/home        jump to top
+  G/end          jump to bottom (re-enables follow)
+  ctrl+b/pgup    page up
+  ctrl+f/pgdown  page down
+  ctrl+u         half page up
+  ctrl+d         half page down
+  /              filter lines
+  yy/Y           copy output (filtered if a filter is on)
+  w              save output (filtered if a filter is on)
+  tab            switch job
+  esc            clear the filter, or back when none is set
+  q              back
+
+any key close
+```
+
+`network-map` has no row because the file unbound it, and the help bar drops its chip to match:
+
+```
+Dig deeper  [i] route table  ·  [s] open sockets  ·  [S] SSH login — needs a target
+
+ctrl+r run the checks  ·  letter runs that tool  ·  ? help  ·  q/Q quit
 ```
 
 `--keys` overrides the file's `keys:` for one run; your `bindings:` still apply on top of it. `--no-config` ignores the file entirely, which is the way back in if a keymap locks you out. netdoc only ever reads the file — it is never created, repaired, or rewritten for you.
@@ -275,7 +321,19 @@ Action names are the ones the `?` cheatsheet lists: `up`, `down`, `top`, `bottom
 
 The cheatsheet and the contextual help bar are generated from your bindings, so they always show the keys that actually run, and an action you unbind stops being advertised. Rebinding covers the check list and the output viewer; the restart prompt, SSH form, filter line, and the tool confirm gate keep fixed keys, since every printable key there belongs to what you are typing. Drill-down tool hotkeys are fixed too — a binding that would shadow one is rejected rather than quietly breaking that tool on the targets that offer it.
 
-A config netdoc cannot use is reported, never fatal: it prints every problem to stderr, says so in the TUI, and runs on the built-in keys. `netdoc` is usually started *during* an outage, so refusing to start over a stale dotfile is the one response that helps nobody.
+A config netdoc cannot use is reported, never fatal: it prints every problem to stderr, says so in the TUI, and runs on the built-in keys. `netdoc` is usually started *during* an outage, so refusing to start over a stale dotfile is the one response that helps nobody. A file with `quti:` where you meant `quit:` gets you this, and a working keymap:
+
+```
+netdoc: /home/you/.netdocrc: unknown action "quti"
+```
+
+```
+✗ .netdocrc: unknown action "quti" — using the built-in keys
+
+r run the checks  ·  v network map  ·  letter runs that tool  ·  ? help  ·  q quit
+```
+
+The stderr line is still on your terminal after netdoc exits, which is where the keymap gets fixed; the notice is what says so while the alt screen has the scrollback. Every problem in the file is listed, not just the first, and none of the bindings are applied — a half-applied keymap is a puzzle with nothing on screen to explain it.
 
 ## Drill-down tools
 

--- a/internal/simulation/netns_integration_test.go
+++ b/internal/simulation/netns_integration_test.go
@@ -1,4 +1,4 @@
-//go:build netns_integration
+//go:build netns_integration && linux
 
 // Opt-in (-tags netns_integration) tests that build real network namespaces.
 //
@@ -7,6 +7,15 @@
 // No root needed: the simulator runs in an unprivileged user namespace. The
 // tests skip themselves on a host where that is unavailable, and nothing they
 // create is reachable from — or visible to — the host network.
+//
+// The linux term is load-bearing, not decoration: these tests reach into the
+// backend's own internals (ipv4ForwardPath, nftTable) to prove the host was
+// left alone, and those live in netns_linux.go. Without it the tag selects
+// this file on macOS and Windows without the code it calls, and the package
+// fails to build rather than skipping — which is what running the gate's netns
+// step on a Mac used to do. Skipping is already this file's answer for a Linux
+// host that cannot make namespaces; a host that cannot even have them wants
+// the same answer one level up.
 
 package simulation
 

--- a/internal/simulation/netns_integration_test.go
+++ b/internal/simulation/netns_integration_test.go
@@ -8,14 +8,9 @@
 // tests skip themselves on a host where that is unavailable, and nothing they
 // create is reachable from — or visible to — the host network.
 //
-// The linux term is load-bearing, not decoration: these tests reach into the
-// backend's own internals (ipv4ForwardPath, nftTable) to prove the host was
-// left alone, and those live in netns_linux.go. Without it the tag selects
-// this file on macOS and Windows without the code it calls, and the package
-// fails to build rather than skipping — which is what running the gate's netns
-// step on a Mac used to do. Skipping is already this file's answer for a Linux
-// host that cannot make namespaces; a host that cannot even have them wants
-// the same answer one level up.
+// The linux term is required: these tests read the backend's own internals
+// (ipv4ForwardPath, nftTable) from netns_linux.go, so without it the tag
+// selects this file on macOS and Windows without the code it calls.
 
 package simulation
 

--- a/internal/ui/keyconfig.go
+++ b/internal/ui/keyconfig.go
@@ -1,6 +1,5 @@
-// The key-binding config file: a small YAML dotfile naming a preset and, on
-// top of it, whatever the user wants moved. netdoc only ever reads it — no
-// file is created, repaired, or rewritten on a user's behalf.
+// The key-binding config file: a small YAML dotfile naming a preset and the
+// keys to move on top of it. netdoc only ever reads it.
 
 package ui
 
@@ -21,8 +20,7 @@ import (
 const maxConfigBytes = 256 << 10
 
 // keyConfig is the file's shape. Unknown fields are rejected rather than
-// ignored: a mistyped `binding:` that silently did nothing would look exactly
-// like netdoc losing the user's keymap, and this file is hand-written.
+// ignored: a mistyped `binding:` would otherwise look like a lost keymap.
 type keyConfig struct {
 	// Keys names a preset to start from. Empty means the default preset.
 	Keys string `yaml:"keys"`
@@ -33,12 +31,9 @@ type keyConfig struct {
 
 // LoadKeymap resolves the keymap for a run: the file at path (empty path, or
 // no file there, means no user config), with preset overriding the file's own
-// `keys:` when the CLI supplied one.
-//
-// It always returns a usable keymap. A broken config is reported, never fatal:
-// the config is normally edited between runs, but netdoc is normally started
-// during an outage, and refusing to start is the one response that helps
-// nobody.
+// `keys:` when the CLI supplied one. It always returns a usable keymap — a
+// broken config is reported but never fatal, since netdoc is usually started
+// during an outage.
 func LoadKeymap(path, preset string) (Keymap, []error) {
 	cfg, err := readKeyConfig(path)
 	if err != nil {

--- a/internal/ui/keyconfig.go
+++ b/internal/ui/keyconfig.go
@@ -1,0 +1,83 @@
+// The key-binding config file: a small YAML dotfile naming a preset and, on
+// top of it, whatever the user wants moved. netdoc only ever reads it — no
+// file is created, repaired, or rewritten on a user's behalf.
+
+package ui
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+
+	"github.com/heymaikol/network-doctor/internal/textsafe"
+	"gopkg.in/yaml.v3"
+)
+
+// maxConfigBytes bounds the read. Nothing about a keymap needs more, and the
+// path is a filename netdoc was pointed at rather than one it validated.
+const maxConfigBytes = 256 << 10
+
+// keyConfig is the file's shape. Unknown fields are rejected rather than
+// ignored: a mistyped `binding:` that silently did nothing would look exactly
+// like netdoc losing the user's keymap, and this file is hand-written.
+type keyConfig struct {
+	// Keys names a preset to start from. Empty means the default preset.
+	Keys string `yaml:"keys"`
+	// Bindings replaces individual actions' keys. Each value is the complete
+	// key list for that action, so an empty list unbinds it.
+	Bindings map[string][]string `yaml:"bindings"`
+}
+
+// LoadKeymap resolves the keymap for a run: the file at path (empty path, or
+// no file there, means no user config), with preset overriding the file's own
+// `keys:` when the CLI supplied one.
+//
+// It always returns a usable keymap. A broken config is reported, never fatal:
+// the config is normally edited between runs, but netdoc is normally started
+// during an outage, and refusing to start is the one response that helps
+// nobody.
+func LoadKeymap(path, preset string) (Keymap, []error) {
+	cfg, err := readKeyConfig(path)
+	if err != nil {
+		km, _ := PresetKeymap(orElse(preset, "default"))
+		return km, []error{err}
+	}
+	// The flag wins over the file: it is the more specific instruction, and
+	// it is how a user gets a working keymap out of a broken file.
+	return buildKeymap(orElse(preset, orElse(cfg.Keys, "default")), cfg.Bindings)
+}
+
+// orElse returns s, or fallback when s is empty.
+func orElse(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+func readKeyConfig(path string) (keyConfig, error) {
+	var cfg keyConfig
+	if path == "" {
+		return cfg, nil
+	}
+	b, err := os.ReadFile(path)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return cfg, nil // nothing configured is not a mistake
+	case err != nil:
+		return cfg, fmt.Errorf("%s", textsafe.Clean(err.Error()))
+	case len(b) > maxConfigBytes:
+		return cfg, fmt.Errorf("config file is larger than %d bytes", maxConfigBytes)
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(b))
+	dec.KnownFields(true)
+	if err := dec.Decode(&cfg); err != nil && !errors.Is(err, io.EOF) {
+		// yaml quotes the offending line back at you, and that line came from
+		// a file netdoc did not write.
+		return keyConfig{}, fmt.Errorf("%s", textsafe.Clean(err.Error()))
+	}
+	return cfg, nil
+}

--- a/internal/ui/keyconfig_test.go
+++ b/internal/ui/keyconfig_test.go
@@ -67,8 +67,15 @@ func TestLoadKeymapFlagOverridesFilePreset(t *testing.T) {
 	if len(errs) > 0 {
 		t.Fatalf("LoadKeymap: %v", errs)
 	}
-	if slices := km.keysFor(actBottom); len(slices) != 1 || slices[0] != "end" {
-		t.Errorf("bottom = %v, want the default end only", slices)
+	// half-page has no default binding and is the vim preset's alone, so it is
+	// the honest test of which preset won.
+	if km.bound(actHalfPageDown) {
+		t.Errorf("half-page-down = %v, want unbound under the default preset", km.keysFor(actHalfPageDown))
+	}
+	// Both presets bind the same top/bottom keys; only their order differs, so
+	// the advertised one says which preset is in force.
+	if got := km.label(actBottom); got != "end/G" {
+		t.Errorf("bottom = %q, want the default order end/G", got)
 	}
 	// The file's own bindings still apply on top of the flag's preset.
 	path = writeConfig(t, "keys: vim\nbindings:\n  quit: [Q]\n")

--- a/internal/ui/keyconfig_test.go
+++ b/internal/ui/keyconfig_test.go
@@ -8,6 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/heymaikol/network-doctor/internal/diagnostic"
 )
 
 func writeConfig(t *testing.T, body string) string {
@@ -157,6 +161,58 @@ func TestLoadKeymapRejectsAnOversizedFile(t *testing.T) {
 		t.Fatalf("errs = %v, want one size complaint", errs)
 	}
 }
+
+// The whole path, as main walks it: a file on disk, through the option, to a
+// keypress the model answers.
+func TestConfiguredKeymapReachesTheModel(t *testing.T) {
+	path := writeConfig(t, "keys: vim\nbindings:\n  restart: [ctrl+r]\n")
+	km, errs := LoadKeymap(path, "")
+	if len(errs) > 0 {
+		t.Fatalf("LoadKeymap: %v", errs)
+	}
+	m := asModel(t, NewWithSelection(nil, nil, true, false, "", "test",
+		diagnostic.DefaultPublicDNS, diagnostic.ProbeSelection{}, WithKeymap(km)))
+	u, _ := m.handleKey(keyPress("ctrl+r"))
+	if !asModel(t, u).entering {
+		t.Error("ctrl+r did not open the restart prompt")
+	}
+	if u, _ := m.handleKey(keyPress("r")); asModel(t, u).entering {
+		t.Error("r still opens the restart prompt after being rebound away")
+	}
+	if help := m.helpView(true); !strings.Contains(help, "ctrl+r") {
+		t.Errorf("help bar = %q, want the configured key", help)
+	}
+}
+
+// A complaint from before the TUI existed has to survive into it: the model
+// opens with it on screen and with the tick that will clear it armed.
+func TestStartupNoticeIsShownAndExpires(t *testing.T) {
+	m := asModel(t, NewWithSelection(nil, nil, true, false, "", "test",
+		diagnostic.DefaultPublicDNS, diagnostic.ProbeSelection{},
+		WithStartupNotice("netdocrc: unknown action \"quti\"\x1b]52;c;aGk=\x07")))
+	if m.notice == "" || m.noticeOK {
+		t.Fatalf("notice = %q ok = %v, want a complaint", m.notice, m.noticeOK)
+	}
+	if strings.ContainsAny(m.notice, "\x1b\x07") {
+		t.Errorf("notice = %q, want the escapes sanitized out", m.notice)
+	}
+	if !strings.Contains(m.View(), "quti") {
+		t.Errorf("the notice is not on the opening screen:\n%s", m.View())
+	}
+	if m.noticeDeadline.IsZero() {
+		t.Fatal("no deadline, so nothing will ever clear the notice")
+	}
+	// Init arms the expiry, since Init's own mutations are discarded.
+	if m.Init() == nil {
+		t.Fatal("Init returned no commands")
+	}
+	cleared := asModel(t, mustUpdated(m.Update(noticeDoneMsg{deadline: m.noticeDeadline})))
+	if cleared.notice != "" {
+		t.Errorf("notice = %q after its deadline, want it cleared", cleared.notice)
+	}
+}
+
+func mustUpdated(m tea.Model, _ tea.Cmd) tea.Model { return m }
 
 // An empty file is a file someone is about to write, not a mistake.
 func TestLoadKeymapAcceptsAnEmptyFile(t *testing.T) {

--- a/internal/ui/keyconfig_test.go
+++ b/internal/ui/keyconfig_test.go
@@ -1,5 +1,5 @@
-// The config file: what a good one does, and what every bad one must do
-// instead — report itself, change nothing, and leave a working keymap behind.
+// The config file: what a good one does, and what a bad one must do instead —
+// report itself, change nothing, and leave a working keymap behind.
 
 package ui
 
@@ -59,8 +59,7 @@ bindings:
 	}
 }
 
-// The flag is the more specific instruction and the way out of a file that
-// picks a preset the user is done with.
+// The flag is the way out of a file that picks a preset the user is done with.
 func TestLoadKeymapFlagOverridesFilePreset(t *testing.T) {
 	path := writeConfig(t, "keys: vim\n")
 	km, errs := LoadKeymap(path, "default")
@@ -100,8 +99,7 @@ func TestLoadKeymapMissingFileIsNotAnError(t *testing.T) {
 	}
 }
 
-// Every rejection has to leave a keymap that works, and leave it whole: a
-// half-applied config is a puzzle nothing on screen explains.
+// Every rejection leaves a working keymap, and leaves it whole.
 func TestLoadKeymapRejectionsChangeNothing(t *testing.T) {
 	tests := []struct {
 		name, body, want string
@@ -137,8 +135,7 @@ func TestLoadKeymapRejectionsChangeNothing(t *testing.T) {
 	}
 }
 
-// Several mistakes are reported together: fixing a keymap one run per typo is
-// the kind of loop that makes people give up and delete the file.
+// Several mistakes are reported together, not one run per typo.
 func TestLoadKeymapReportsEveryError(t *testing.T) {
 	_, errs := LoadKeymap(writeConfig(t, "bindings:\n  quti: [Q]\n  help: [nope]\n  quit: [n]\n"), "")
 	if len(errs) != 3 {
@@ -146,8 +143,7 @@ func TestLoadKeymapReportsEveryError(t *testing.T) {
 	}
 }
 
-// The file is external input, so what it says can reach the screen only after
-// the sanitizer has seen it.
+// The file is external input, so it reaches the screen only sanitized.
 func TestLoadKeymapErrorsAreSanitized(t *testing.T) {
 	_, errs := LoadKeymap(writeConfig(t, "bindings:\n  \"\\e]52;c;aGk=\\a\": [Q]\n"), "")
 	if len(errs) == 0 {
@@ -169,7 +165,7 @@ func TestLoadKeymapRejectsAnOversizedFile(t *testing.T) {
 	}
 }
 
-// The whole path, as main walks it: a file on disk, through the option, to a
+// The whole path as main walks it: a file on disk, through the option, to a
 // keypress the model answers.
 func TestConfiguredKeymapReachesTheModel(t *testing.T) {
 	path := writeConfig(t, "keys: vim\nbindings:\n  restart: [ctrl+r]\n")
@@ -191,8 +187,8 @@ func TestConfiguredKeymapReachesTheModel(t *testing.T) {
 	}
 }
 
-// A complaint from before the TUI existed has to survive into it: the model
-// opens with it on screen and with the tick that will clear it armed.
+// A complaint from before the TUI existed has to survive into it, with the
+// tick that will clear it armed.
 func TestStartupNoticeIsShownAndExpires(t *testing.T) {
 	m := asModel(t, NewWithSelection(nil, nil, true, false, "", "test",
 		diagnostic.DefaultPublicDNS, diagnostic.ProbeSelection{},

--- a/internal/ui/keyconfig_test.go
+++ b/internal/ui/keyconfig_test.go
@@ -1,0 +1,172 @@
+// The config file: what a good one does, and what every bad one must do
+// instead — report itself, change nothing, and leave a working keymap behind.
+
+package ui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "netdocrc")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestLoadKeymapAppliesPresetAndOverrides(t *testing.T) {
+	path := writeConfig(t, `
+keys: vim
+bindings:
+  quit: [Q, ctrl+q]
+  help: [f1]
+  restart: []
+`)
+	km, errs := LoadKeymap(path, "")
+	if len(errs) > 0 {
+		t.Fatalf("LoadKeymap: %v", errs)
+	}
+	m := newModel(nil, false)
+	m.keys = km
+	tests := []struct {
+		key  string
+		want keyAction
+	}{
+		{"Q", actQuit},
+		{"ctrl+q", actQuit},
+		{"f1", actHelp},
+		{"G", actBottom}, // the vim preset underneath
+		{"q", actNone},   // the key quit moved off
+		{"?", actNone},   // and the key help moved off
+		{"r", actNone},   // restart is unbound outright
+	}
+	for _, tt := range tests {
+		if act, _ := m.resolveKey(ctxList, tt.key); act != tt.want {
+			t.Errorf("%q = action %d, want %d", tt.key, act, tt.want)
+		}
+	}
+	if km.bound(actRestart) {
+		t.Error("an empty binding list left restart bound")
+	}
+}
+
+// The flag is the more specific instruction and the way out of a file that
+// picks a preset the user is done with.
+func TestLoadKeymapFlagOverridesFilePreset(t *testing.T) {
+	path := writeConfig(t, "keys: vim\n")
+	km, errs := LoadKeymap(path, "default")
+	if len(errs) > 0 {
+		t.Fatalf("LoadKeymap: %v", errs)
+	}
+	if slices := km.keysFor(actBottom); len(slices) != 1 || slices[0] != "end" {
+		t.Errorf("bottom = %v, want the default end only", slices)
+	}
+	// The file's own bindings still apply on top of the flag's preset.
+	path = writeConfig(t, "keys: vim\nbindings:\n  quit: [Q]\n")
+	km, errs = LoadKeymap(path, "default")
+	if len(errs) > 0 {
+		t.Fatalf("LoadKeymap: %v", errs)
+	}
+	if got := km.label(actQuit); got != "Q" {
+		t.Errorf("quit = %q, want Q", got)
+	}
+}
+
+func TestLoadKeymapMissingFileIsNotAnError(t *testing.T) {
+	for _, path := range []string{"", filepath.Join(t.TempDir(), "absent")} {
+		km, errs := LoadKeymap(path, "")
+		if len(errs) > 0 {
+			t.Errorf("LoadKeymap(%q) = %v, want no errors", path, errs)
+		}
+		if got := km.label(actQuit); got != "q" {
+			t.Errorf("LoadKeymap(%q) quit = %q, want the default q", path, got)
+		}
+	}
+}
+
+// Every rejection has to leave a keymap that works, and leave it whole: a
+// half-applied config is a puzzle nothing on screen explains.
+func TestLoadKeymapRejectionsChangeNothing(t *testing.T) {
+	tests := []struct {
+		name, body, want string
+	}{
+		{"unknown action", "bindings:\n  quti: [Q]\n", `unknown action "quti"`},
+		{"unknown key", "bindings:\n  quit: [suprr]\n", "unknown key"},
+		{"chord written without spaces", "bindings:\n  top: [gg]\n", "a chord is written with spaces"},
+		{"named key miscapitalized", "bindings:\n  help: [F1]\n", "named keys are lower case"},
+		{"shadows a tool hotkey", "bindings:\n  quit: [n]\n", "toolbox uses"},
+		{"two actions on one key", "bindings:\n  help: [r]\n", "bound to both"},
+		{"binding buried under a chord", "bindings:\n  help: [g]\n  top: [g g]\n", "start of"},
+		{"unknown field", "keybindings:\n  quit: [Q]\n", "field keybindings"},
+		{"not yaml at all", "quit = Q\n", "cannot unmarshal"},
+		{"unknown preset", "keys: emacs\n", "unknown key preset"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			km, errs := LoadKeymap(writeConfig(t, tt.body), "")
+			if len(errs) == 0 {
+				t.Fatalf("%s was accepted", tt.name)
+			}
+			if !strings.Contains(errs[0].Error(), tt.want) {
+				t.Errorf("error = %v, want it to mention %q", errs[0], tt.want)
+			}
+			// Whatever was wrong, the surviving keymap is the built-in one.
+			if got := km.label(actQuit); got != "q" {
+				t.Errorf("quit = %q, want the built-in q", got)
+			}
+			if got := km.label(actHelp); got != "?" {
+				t.Errorf("help = %q, want the built-in ?", got)
+			}
+		})
+	}
+}
+
+// Several mistakes are reported together: fixing a keymap one run per typo is
+// the kind of loop that makes people give up and delete the file.
+func TestLoadKeymapReportsEveryError(t *testing.T) {
+	_, errs := LoadKeymap(writeConfig(t, "bindings:\n  quti: [Q]\n  help: [nope]\n  quit: [n]\n"), "")
+	if len(errs) != 3 {
+		t.Fatalf("got %d errors, want 3: %v", len(errs), errs)
+	}
+}
+
+// The file is external input, so what it says can reach the screen only after
+// the sanitizer has seen it.
+func TestLoadKeymapErrorsAreSanitized(t *testing.T) {
+	_, errs := LoadKeymap(writeConfig(t, "bindings:\n  \"\\e]52;c;aGk=\\a\": [Q]\n"), "")
+	if len(errs) == 0 {
+		t.Fatal("an escape-laden action name was accepted")
+	}
+	for _, err := range errs {
+		for _, bad := range []string{"\x1b", "\a"} {
+			if strings.Contains(err.Error(), bad) {
+				t.Errorf("error %q still carries %q", err, bad)
+			}
+		}
+	}
+}
+
+func TestLoadKeymapRejectsAnOversizedFile(t *testing.T) {
+	_, errs := LoadKeymap(writeConfig(t, strings.Repeat("# padding\n", maxConfigBytes/10+1)), "")
+	if len(errs) != 1 || !strings.Contains(errs[0].Error(), "larger than") {
+		t.Fatalf("errs = %v, want one size complaint", errs)
+	}
+}
+
+// An empty file is a file someone is about to write, not a mistake.
+func TestLoadKeymapAcceptsAnEmptyFile(t *testing.T) {
+	for _, body := range []string{"", "\n", "# just a comment\n"} {
+		km, errs := LoadKeymap(writeConfig(t, body), "")
+		if len(errs) > 0 {
+			t.Errorf("LoadKeymap(%q) = %v, want no errors", body, errs)
+		}
+		if got := km.label(actQuit); got != "q" {
+			t.Errorf("LoadKeymap(%q) quit = %q, want q", body, got)
+		}
+	}
+}

--- a/internal/ui/keyhelp_test.go
+++ b/internal/ui/keyhelp_test.go
@@ -1,0 +1,258 @@
+// The cheatsheet as a screen of its own: reachable from the output viewer,
+// scrollable when it outgrows the terminal, and still closed by anything that
+// isn't a motion.
+
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// viewerWith opens the full-screen output viewer on a finished job holding n
+// lines — the shape a route table or an open-sockets dump arrives in.
+func viewerWith(t *testing.T, name string, n int) model {
+	t.Helper()
+	m := newModel(nil, false)
+	m.width, m.height = 92, 20
+	m.cur.name, m.cur.display, m.cur.status = name, name, JobDone
+	for i := range n {
+		m.appendJobLine(fmt.Sprintf("%s line %d", name, i))
+	}
+	u, _ := m.handleKey(keyPress("enter"))
+	m = asModel(t, u)
+	if !m.viewing {
+		t.Fatal("enter did not open the output viewer")
+	}
+	return m
+}
+
+// The tools the user reaches for first are the two that need no target, and
+// their output is read in the viewer. Both jump keys have to work there on a
+// stock netdoc, with no config file in sight.
+func TestJumpKeysScrollToolOutputByDefault(t *testing.T) {
+	for _, tool := range []string{"route table", "open sockets"} {
+		t.Run(tool, func(t *testing.T) {
+			m := viewerWith(t, tool, 300)
+			if m.vp.YOffset == 0 {
+				t.Fatal("the viewer did not open at the tail")
+			}
+			press := func(m model, key string) model {
+				t.Helper()
+				u, _ := m.handleViewKey(keyPress(key))
+				return asModel(t, u)
+			}
+			// gg is a chord: the first g must move nothing.
+			mid := press(m, "g")
+			if mid.vp.YOffset != m.vp.YOffset {
+				t.Errorf("the first g scrolled to %d on its own", mid.vp.YOffset)
+			}
+			top := press(mid, "g")
+			if top.vp.YOffset != 0 || top.follow {
+				t.Errorf("gg left offset %d follow %v, want the top", top.vp.YOffset, top.follow)
+			}
+			bottom := press(top, "G")
+			if bottom.vp.YOffset == 0 || !bottom.follow {
+				t.Errorf("G left offset %d follow %v, want the bottom", bottom.vp.YOffset, bottom.follow)
+			}
+		})
+	}
+}
+
+// The same two keys on the check list and the network map, also stock.
+func TestJumpKeysMoveTheListAndMapByDefault(t *testing.T) {
+	m := newModel(mustTarget(t, "example.com"), false)
+	if len(m.probes) < 2 {
+		t.Fatalf("need at least two probes, got %d", len(m.probes))
+	}
+	last := pressed(t, m, keyPress("G"))
+	if last.selected != len(m.probes)-1 {
+		t.Errorf("G selected row %d, want %d", last.selected, len(m.probes)-1)
+	}
+	mid := pressed(t, last, keyPress("g"))
+	if mid.selected != last.selected {
+		t.Errorf("the first g moved the cursor to %d", mid.selected)
+	}
+	if first := pressed(t, mid, keyPress("g")); first.selected != 0 {
+		t.Errorf("gg selected row %d, want 0", first.selected)
+	}
+
+	nm := newModel(nil, false)
+	nm.networkMap = true
+	nm.cur.name, nm.cur.status = lanDiscoveryName, JobDone
+	nm.cur.lines = []string{
+		"Host: 192.168.12.1 (router.lan.example)\tStatus: Up",
+		"Host: 192.168.12.50 (living-room-tv.lan.example)\tStatus: Up",
+		"Host: 192.168.12.51 ()\tStatus: Up",
+	}
+	end := pressed(t, nm, keyPress("G"))
+	if end.mapSelected != len(nm.networkHosts())-1 {
+		t.Errorf("G selected device %d, want the last", end.mapSelected)
+	}
+	back := pressed(t, pressed(t, end, keyPress("g")), keyPress("g"))
+	if back.mapSelected != 0 {
+		t.Errorf("gg selected device %d, want 0", back.mapSelected)
+	}
+}
+
+// The viewer used to be the one screen that could not answer "what does this
+// key do", which is exactly where the question comes up.
+func TestHelpOpensFromTheOutputViewer(t *testing.T) {
+	m := viewerWith(t, "route table", 40)
+	u, _ := m.Update(keyPress("?"))
+	hm := asModel(t, u)
+	if !hm.helping {
+		t.Fatal("? did not open the cheatsheet from the viewer")
+	}
+	if !strings.Contains(hm.View(), "Output viewer") {
+		t.Error("the cheatsheet is missing its viewer section")
+	}
+	// The viewer is still open underneath, so closing returns to the output
+	// rather than dropping the user back on the check list.
+	if !hm.viewing {
+		t.Fatal("opening the cheatsheet closed the viewer")
+	}
+	closed := asModel(t, mustModel(hm.Update(keyPress("x"))))
+	if closed.helping || !closed.viewing {
+		t.Errorf("after closing: helping=%v viewing=%v, want false/true", closed.helping, closed.viewing)
+	}
+	if !strings.Contains(closed.View(), "route table line 39") {
+		t.Error("the output did not come back")
+	}
+	// ? toggles: it is not a motion, so it closes like anything else.
+	if again := asModel(t, mustModel(hm.Update(keyPress("?")))); again.helping {
+		t.Error("? did not close the cheatsheet")
+	}
+}
+
+func mustModel(m tea.Model, _ tea.Cmd) tea.Model { return m }
+
+// The reported path, end to end and through the one entry point every key
+// takes: run the tool, then ask for help — on the pane it lands in, and in the
+// full-screen view of it. Both are "the route table screen" to whoever is
+// looking at one.
+func TestHelpAnswersAfterRunningATool(t *testing.T) {
+	oldLookPath := toolLookPath
+	// Missing on purpose: launchTool then reports "not found" in a pane
+	// instead of forking anything, which is the same pane a real run fills.
+	toolLookPath = func(string) (string, error) { return "", fmt.Errorf("not found") }
+	t.Cleanup(func() { toolLookPath = oldLookPath })
+
+	for _, tool := range []struct{ key, name string }{{"i", "route table"}, {"s", "open sockets"}} {
+		t.Run(tool.name, func(t *testing.T) {
+			m := newModel(nil, true)
+			m.width, m.height = 92, 30
+			ran := asModel(t, mustModel(m.Update(keyPress(tool.key))))
+			if !ran.hasJob() || !strings.Contains(ran.cur.name, tool.name) {
+				t.Fatalf("%q did not open the %s pane (job %q)", tool.key, tool.name, ran.cur.name)
+			}
+			// On the main screen, with the tool's pane on it.
+			onPane := asModel(t, mustModel(ran.Update(keyPress("?"))))
+			if !onPane.helping {
+				t.Error("? did not open the cheatsheet with the tool pane showing")
+			}
+			// And in the full-screen view of the same output.
+			viewing := asModel(t, mustModel(ran.Update(keyPress("enter"))))
+			if !viewing.viewing {
+				t.Fatal("enter did not open the full output")
+			}
+			inViewer := asModel(t, mustModel(viewing.Update(keyPress("?"))))
+			if !inViewer.helping {
+				t.Error("? did not open the cheatsheet from the full output")
+			}
+			if !inViewer.viewing {
+				t.Error("the output was closed instead of being covered")
+			}
+		})
+	}
+}
+
+// The sheet is longer than a short terminal, and it used to be cut off there
+// with no way to reach the rest.
+func TestCheatsheetScrollsInsteadOfBeingCutOff(t *testing.T) {
+	m := newModel(mustTarget(t, "example.com"), false)
+	m.width, m.height = 92, 16
+	body := m.helpBody()
+	if len(body) <= m.helpVisible() {
+		t.Fatalf("cheatsheet is %d rows and %d fit; this test needs it to overflow", len(body), m.helpVisible())
+	}
+	// A row from the viewer section, which is the half that used to be cut
+	// off. Not simply the last row: that one is ?, which the list section
+	// carries too, so finding it on screen would prove nothing.
+	var lastRow string
+	for _, line := range body {
+		if strings.Contains(line, "clear the filter") {
+			lastRow = line
+		}
+	}
+	if lastRow == "" {
+		t.Fatal("no clear-filter row in the cheatsheet to look for")
+	}
+
+	open := asModel(t, mustModel(m.Update(keyPress("?"))))
+	if strings.Contains(open.View(), lastRow) {
+		t.Fatal("the whole sheet fits after all; the test proves nothing")
+	}
+	if got := strings.Count(open.View(), "\n") + 1; got > m.height {
+		t.Errorf("the sheet renders %d rows into a %d-row terminal", got, m.height)
+	}
+
+	bottom := asModel(t, mustModel(open.Update(keyPress("G"))))
+	if !bottom.helping {
+		t.Fatal("G closed the sheet instead of scrolling it")
+	}
+	if !strings.Contains(bottom.View(), lastRow) {
+		t.Errorf("G did not reach the last row:\n%s", bottom.View())
+	}
+	// A half-typed chord is not "any other key".
+	half := asModel(t, mustModel(bottom.Update(keyPress("g"))))
+	if !half.helping {
+		t.Fatal("the first g of gg closed the sheet")
+	}
+	top := asModel(t, mustModel(half.Update(keyPress("g"))))
+	if !top.helping || top.helpOffset != 0 {
+		t.Errorf("gg left helping=%v offset=%d, want open at the top", top.helping, top.helpOffset)
+	}
+	if !strings.Contains(top.View(), body[0]) {
+		t.Error("gg did not bring the first row back")
+	}
+	// Line and page motions keep it open too; everything else still closes it.
+	for _, key := range []string{"down", "j", "up", "k", "pgdown", "pgup", "home", "end"} {
+		if next := asModel(t, mustModel(top.Update(keyPress(key)))); !next.helping {
+			t.Errorf("%q closed the sheet instead of scrolling it", key)
+		}
+	}
+	for _, key := range []string{"x", "r", "esc", "q", "?"} {
+		if next := asModel(t, mustModel(top.Update(keyPress(key)))); next.helping {
+			t.Errorf("%q did not close the sheet", key)
+		}
+	}
+	// Reopening starts at the top rather than wherever it was left.
+	reopened := asModel(t, mustModel(asModel(t, mustModel(bottom.Update(keyPress("x")))).Update(keyPress("?"))))
+	if reopened.helpOffset != 0 {
+		t.Errorf("reopened at offset %d, want the top", reopened.helpOffset)
+	}
+}
+
+// Keys typed fast arrive as one KeyMsg. Splitting them has to happen before
+// any screen sees them, or a chord reads as a single unknown key — which on
+// the cheatsheet means "close" rather than "jump to the top".
+func TestFastChordIsNotOneKey(t *testing.T) {
+	m := newModel(mustTarget(t, "example.com"), false)
+	m.width, m.height = 92, 16
+	open := asModel(t, mustModel(m.Update(keyPress("?"))))
+	bottom := asModel(t, mustModel(open.Update(keyPress("G"))))
+	if bottom.helpOffset == 0 {
+		t.Fatal("G did not scroll")
+	}
+	fast := asModel(t, mustModel(bottom.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("gg")})))
+	if !fast.helping {
+		t.Fatal("a fast gg closed the cheatsheet")
+	}
+	if fast.helpOffset != 0 {
+		t.Errorf("a fast gg left offset %d, want the top", fast.helpOffset)
+	}
+}

--- a/internal/ui/keyhelp_test.go
+++ b/internal/ui/keyhelp_test.go
@@ -1,6 +1,5 @@
 // The cheatsheet as a screen of its own: reachable from the output viewer,
-// scrollable when it outgrows the terminal, and still closed by anything that
-// isn't a motion.
+// scrollable, and still closed by anything that is not a motion.
 
 package ui
 
@@ -12,8 +11,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// viewerWith opens the full-screen output viewer on a finished job holding n
-// lines — the shape a route table or an open-sockets dump arrives in.
+// viewerWith opens the output viewer on a finished job holding n lines — the
+// shape a route table or open-sockets dump arrives in.
 func viewerWith(t *testing.T, name string, n int) model {
 	t.Helper()
 	m := newModel(nil, false)
@@ -30,9 +29,7 @@ func viewerWith(t *testing.T, name string, n int) model {
 	return m
 }
 
-// The tools the user reaches for first are the two that need no target, and
-// their output is read in the viewer. Both jump keys have to work there on a
-// stock netdoc, with no config file in sight.
+// Both jump keys have to work on tool output with no config file in sight.
 func TestJumpKeysScrollToolOutputByDefault(t *testing.T) {
 	for _, tool := range []string{"route table", "open sockets"} {
 		t.Run(tool, func(t *testing.T) {
@@ -62,7 +59,7 @@ func TestJumpKeysScrollToolOutputByDefault(t *testing.T) {
 	}
 }
 
-// The same two keys on the check list and the network map, also stock.
+// The same two keys on the check list and the network map.
 func TestJumpKeysMoveTheListAndMapByDefault(t *testing.T) {
 	m := newModel(mustTarget(t, "example.com"), false)
 	if len(m.probes) < 2 {
@@ -130,10 +127,8 @@ func TestHelpOpensFromTheOutputViewer(t *testing.T) {
 
 func mustModel(m tea.Model, _ tea.Cmd) tea.Model { return m }
 
-// The reported path, end to end and through the one entry point every key
-// takes: run the tool, then ask for help — on the pane it lands in, and in the
-// full-screen view of it. Both are "the route table screen" to whoever is
-// looking at one.
+// The reported path: run the tool, then ask for help — on the pane it lands in
+// and in the full-screen view of it.
 func TestHelpAnswersAfterRunningATool(t *testing.T) {
 	oldLookPath := toolLookPath
 	// Missing on purpose: launchTool then reports "not found" in a pane
@@ -170,8 +165,8 @@ func TestHelpAnswersAfterRunningATool(t *testing.T) {
 	}
 }
 
-// The sheet is longer than a short terminal, and it used to be cut off there
-// with no way to reach the rest.
+// The sheet is longer than a short terminal, and used to be cut off with no
+// way to reach the rest.
 func TestCheatsheetScrollsInsteadOfBeingCutOff(t *testing.T) {
 	m := newModel(mustTarget(t, "example.com"), false)
 	m.width, m.height = 92, 16
@@ -179,9 +174,8 @@ func TestCheatsheetScrollsInsteadOfBeingCutOff(t *testing.T) {
 	if len(body) <= m.helpVisible() {
 		t.Fatalf("cheatsheet is %d rows and %d fit; this test needs it to overflow", len(body), m.helpVisible())
 	}
-	// A row from the viewer section, which is the half that used to be cut
-	// off. Not simply the last row: that one is ?, which the list section
-	// carries too, so finding it on screen would prove nothing.
+	// A row from the viewer section, the half that used to be cut off. Not the
+	// last row: that one is ?, which the list section carries too.
 	var lastRow string
 	for _, line := range body {
 		if strings.Contains(line, "clear the filter") {
@@ -238,8 +232,7 @@ func TestCheatsheetScrollsInsteadOfBeingCutOff(t *testing.T) {
 }
 
 // Keys typed fast arrive as one KeyMsg. Splitting them has to happen before
-// any screen sees them, or a chord reads as a single unknown key — which on
-// the cheatsheet means "close" rather than "jump to the top".
+// any screen sees them, or a chord reads as one unknown key — here, "close".
 func TestFastChordIsNotOneKey(t *testing.T) {
 	m := newModel(mustTarget(t, "example.com"), false)
 	m.width, m.height = 92, 16

--- a/internal/ui/keyjump_test.go
+++ b/internal/ui/keyjump_test.go
@@ -1,0 +1,73 @@
+// Jumping to the first and last row, in the check list and on the network map.
+
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func pressed(t *testing.T, m model, msg tea.KeyMsg) model {
+	t.Helper()
+	u, _ := m.handleKey(msg)
+	return asModel(t, u)
+}
+
+var (
+	homeKey = tea.KeyMsg{Type: tea.KeyHome}
+	endKey  = tea.KeyMsg{Type: tea.KeyEnd}
+)
+
+func TestListJumpsToFirstAndLastCheck(t *testing.T) {
+	m := newModel(mustTarget(t, "example.com"), false)
+	if len(m.probes) < 2 {
+		t.Fatalf("need at least two probes, got %d", len(m.probes))
+	}
+	end := pressed(t, m, endKey)
+	if end.selected != len(m.probes)-1 {
+		t.Errorf("end selected row %d, want %d", end.selected, len(m.probes)-1)
+	}
+	if !end.selMoved {
+		t.Error("end did not count as the user moving the cursor, so completion may yank it away")
+	}
+	if home := pressed(t, end, homeKey); home.selected != 0 {
+		t.Errorf("home selected row %d, want 0", home.selected)
+	}
+}
+
+// The jump can arrive before any probe has reported, when the list is still
+// empty; selecting row -1 would be an out-of-range render.
+func TestListJumpSurvivesAnEmptyList(t *testing.T) {
+	m := newModel(nil, false)
+	m.probes = nil
+	if got := pressed(t, m, endKey).selected; got != 0 {
+		t.Errorf("end on an empty list selected %d, want 0", got)
+	}
+}
+
+// On the network map the same keys move the device cursor, as up/down do.
+func TestMapJumpsToFirstAndLastDevice(t *testing.T) {
+	m := newModel(nil, false)
+	m.networkMap = true
+	m.cur.name, m.cur.status = lanDiscoveryName, JobDone
+	m.cur.lines = []string{
+		"Host: 192.168.12.1 (router.lan.example)\tStatus: Up",
+		"Host: 192.168.12.50 (living-room-tv.lan.example)\tStatus: Up",
+		"Host: 192.168.12.51 ()\tStatus: Up",
+	}
+	hosts := len(m.networkHosts())
+	if hosts != 3 {
+		t.Fatalf("networkHosts() = %d, want 3", hosts)
+	}
+	end := pressed(t, m, endKey)
+	if end.mapSelected != hosts-1 {
+		t.Errorf("end selected device %d, want %d", end.mapSelected, hosts-1)
+	}
+	if end.selected != 0 {
+		t.Errorf("the check cursor moved to %d while the map was open", end.selected)
+	}
+	if home := pressed(t, end, homeKey); home.mapSelected != 0 {
+		t.Errorf("home selected device %d, want 0", home.mapSelected)
+	}
+}

--- a/internal/ui/keyjump_test.go
+++ b/internal/ui/keyjump_test.go
@@ -14,24 +14,19 @@ func pressed(t *testing.T, m model, msg tea.KeyMsg) model {
 	return asModel(t, u)
 }
 
-var (
-	homeKey = tea.KeyMsg{Type: tea.KeyHome}
-	endKey  = tea.KeyMsg{Type: tea.KeyEnd}
-)
-
 func TestListJumpsToFirstAndLastCheck(t *testing.T) {
 	m := newModel(mustTarget(t, "example.com"), false)
 	if len(m.probes) < 2 {
 		t.Fatalf("need at least two probes, got %d", len(m.probes))
 	}
-	end := pressed(t, m, endKey)
+	end := pressed(t, m, keyPress("end"))
 	if end.selected != len(m.probes)-1 {
 		t.Errorf("end selected row %d, want %d", end.selected, len(m.probes)-1)
 	}
 	if !end.selMoved {
 		t.Error("end did not count as the user moving the cursor, so completion may yank it away")
 	}
-	if home := pressed(t, end, homeKey); home.selected != 0 {
+	if home := pressed(t, end, keyPress("home")); home.selected != 0 {
 		t.Errorf("home selected row %d, want 0", home.selected)
 	}
 }
@@ -41,7 +36,7 @@ func TestListJumpsToFirstAndLastCheck(t *testing.T) {
 func TestListJumpSurvivesAnEmptyList(t *testing.T) {
 	m := newModel(nil, false)
 	m.probes = nil
-	if got := pressed(t, m, endKey).selected; got != 0 {
+	if got := pressed(t, m, keyPress("end")).selected; got != 0 {
 		t.Errorf("end on an empty list selected %d, want 0", got)
 	}
 }
@@ -60,14 +55,14 @@ func TestMapJumpsToFirstAndLastDevice(t *testing.T) {
 	if hosts != 3 {
 		t.Fatalf("networkHosts() = %d, want 3", hosts)
 	}
-	end := pressed(t, m, endKey)
+	end := pressed(t, m, keyPress("end"))
 	if end.mapSelected != hosts-1 {
 		t.Errorf("end selected device %d, want %d", end.mapSelected, hosts-1)
 	}
 	if end.selected != 0 {
 		t.Errorf("the check cursor moved to %d while the map was open", end.selected)
 	}
-	if home := pressed(t, end, homeKey); home.mapSelected != 0 {
+	if home := pressed(t, end, keyPress("home")); home.mapSelected != 0 {
 		t.Errorf("home selected device %d, want 0", home.mapSelected)
 	}
 }

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -82,8 +82,14 @@ var actionDefs = []actionDef{
 		ctxList:   "next check — or device on the network map",
 		ctxViewer: "scroll down",
 	}},
-	{actTop, "top", map[keyContext]string{ctxViewer: "jump to top"}},
-	{actBottom, "bottom", map[keyContext]string{ctxViewer: "jump to bottom (re-enables follow)"}},
+	{actTop, "top", map[keyContext]string{
+		ctxList:   "first check — or device on the network map",
+		ctxViewer: "jump to top",
+	}},
+	{actBottom, "bottom", map[keyContext]string{
+		ctxList:   "last check — or device on the network map",
+		ctxViewer: "jump to bottom (re-enables follow)",
+	}},
 	// Paging is viewer-only on purpose: the check list is rendered whole, so
 	// there is no page below the fold to move by — top/bottom already reach
 	// everything a page key could.

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -1,8 +1,5 @@
-// Key bindings as data. One table drives three things that used to be three
-// hand-maintained copies of the same letters: what a key does, what the
-// contextual help bar advertises, and what the ? cheatsheet lists. A binding
-// can no longer exist without a help entry, or drift from the key that
-// actually runs it.
+// Key bindings as data: one table drives what a key does, what the help bar
+// advertises, and what the ? cheatsheet lists, so the three cannot drift.
 
 package ui
 
@@ -46,13 +43,10 @@ const (
 	actQuit
 )
 
-// keyContext is the screen a binding applies to. The text-entry screens — the
-// restart prompt, the SSH form, the filter line — are deliberately absent:
-// every printable key there belongs to the input, so a binding on this table
-// would take a letter away from typing rather than give the user a shortcut.
-// The confirm gate is absent for the same reason in reverse: y/esc on a shown
-// command is a safety question, not a shortcut, and it stays where the muscle
-// memory of every other confirm prompt puts it.
+// keyContext is the screen a binding applies to. The text-entry screens (the
+// restart prompt, the SSH form, the filter line) and the confirm gate are
+// absent: every printable key there belongs to the input or to a safety
+// question, not to a shortcut.
 type keyContext int
 
 const (
@@ -61,10 +55,8 @@ const (
 	numContexts
 )
 
-// actionDef is an action's name in the config file and its cheatsheet line
-// per context. A context missing from desc is a context the action does not
-// exist in, which is also what makes config validation context-aware: binding
-// `filter` costs the viewer a key and the check list nothing.
+// actionDef is an action's config name and its cheatsheet line per context.
+// A context missing from desc is one the action does not exist in.
 type actionDef struct {
 	act  keyAction
 	name string
@@ -90,9 +82,8 @@ var actionDefs = []actionDef{
 		ctxList:   "last check — or device on the network map",
 		ctxViewer: "jump to bottom (re-enables follow)",
 	}},
-	// Paging is viewer-only on purpose: the check list is rendered whole, so
-	// there is no page below the fold to move by — top/bottom already reach
-	// everything a page key could.
+	// Paging is viewer-only: the check list is rendered whole, so top/bottom
+	// already reach everything a page key could.
 	{actPageUp, "page-up", map[keyContext]string{ctxViewer: "page up"}},
 	{actPageDown, "page-down", map[keyContext]string{ctxViewer: "page down"}},
 	{actHalfPageUp, "half-page-up", map[keyContext]string{ctxViewer: "half page up"}},
@@ -117,14 +108,11 @@ var actionDefs = []actionDef{
 	{actNetworkMap, "network-map", map[keyContext]string{ctxList: "toggle network map"}},
 	{actRestart, "restart", map[keyContext]string{ctxList: "restart with a new target"}},
 	{actSSH, "ssh", map[keyContext]string{ctxList: "ssh to a host — hands the terminal to ssh"}},
-	// Two actions rather than one so that a filtered viewer keeps its
-	// two-step exit: the key that clears a filter is not the key that leaves
-	// with one still applied, and each stays rebindable on its own.
+	// Two actions, so a filtered viewer keeps its two-step exit: the key that
+	// clears a filter is not the key that leaves with one applied.
 	{actClearFilter, "clear-filter", map[keyContext]string{ctxViewer: "clear the filter, or back when none is set"}},
 	{actBack, "back", map[keyContext]string{ctxViewer: "back"}},
-	// Reachable from the output viewer too: a tool's full output is exactly
-	// where someone wonders what a key does, and it used to be the one screen
-	// that could not answer.
+	// Also in the viewer: a tool's full output is where the question comes up.
 	{actHelp, "help", map[keyContext]string{
 		ctxList:   "full-screen key cheatsheet",
 		ctxViewer: "full-screen key cheatsheet",
@@ -132,14 +120,10 @@ var actionDefs = []actionDef{
 	{actQuit, "quit", map[keyContext]string{ctxList: "quit"}},
 }
 
-// defaultPreset is the historical keymap: every letter netdoc has ever
-// answered to, plus the jump keys that had no binding before.
-//
-// gg and G are here rather than in the vim preset because they cost a
-// non-vim user nothing — both keys did nothing at all before, and a lone g
-// still lets the key after it behave exactly as it would have. A jump to the
-// top of a long route table should not require a config file. home and end
-// are listed first, so the help bar advertises the spelling everyone knows.
+// defaultPreset is the historical keymap plus the jump keys that had no
+// binding before. gg and G are here rather than in the vim preset because they
+// cost a non-vim user nothing: both keys did nothing at all before. home and
+// end are listed first, so the help bar advertises the familiar spelling.
 var defaultPreset = map[keyAction][]string{
 	actUp:           {"up", "k"},
 	actDown:         {"down", "j"},
@@ -164,16 +148,10 @@ var defaultPreset = map[keyAction][]string{
 	actQuit:         {"q"},
 }
 
-// vimOverlay is what `keys: vim` changes, and it is deliberately short: j/k,
-// /, y, gg and G are already in the default keymap, so what is left is the
-// ctrl-motions — the ones that would cost a non-vim user a key they might
-// want for something else. Nothing is taken away: pgup/pgdown keep working,
-// because a preset that unbound them would trade one set of habits for
-// another rather than add to it.
-//
-// top and bottom are relisted only to reorder them. The keys are the same
-// ones the default binds; putting vim's spelling first is what makes the help
-// bar read gg/G instead of home/end, so the preset says out loud that it is on.
+// vimOverlay is what `keys: vim` adds: the ctrl-motions, the only ones that
+// would cost a non-vim user a key. Nothing is taken away — pgup/pgdown keep
+// working. top and bottom are relisted only to put vim's spelling first, which
+// is what makes the help bar read gg/G instead of home/end.
 var vimOverlay = map[keyAction][]string{
 	actTop:          {"g g", "home"},
 	actBottom:       {"G", "end"},
@@ -207,16 +185,11 @@ func PresetKeymap(name string) (Keymap, error) {
 // presetNames lists the presets for error messages, in a stable order.
 func presetNames() []string { return slices.Sorted(maps.Keys(presets)) }
 
-// keyNames is every key name a binding may use, spelled the way Bubble Tea
-// spells it when the key arrives — the set is built by asking Bubble Tea for
-// each name rather than by copying the strings, so a binding can never be
-// written in a spelling that no keypress will ever match ("pgdn" for
-// "pgdown"). Printable single runes are accepted on top of these.
-//
-// Absent on purpose: ctrl+c (the terminal's own way out, and the second press
-// quits whatever quit is bound to), ctrl+h/ctrl+i/ctrl+j/ctrl+m (the same
-// bytes as backspace/tab/enter, so binding them would move a key the user did
-// not name), and ctrl+z (the shell's job control).
+// bindableKeyTypes are the keys a binding may name. Bubble Tea supplies the
+// spellings, so a binding can never be written in one no keypress will match
+// ("pgdn" for "pgdown"); printable single runes are accepted on top of them.
+// Absent on purpose: ctrl+c (the terminal's own way out), ctrl+h/i/j/m (the
+// same bytes as backspace/tab/enter), and ctrl+z (job control).
 var bindableKeyTypes = []tea.KeyType{
 	tea.KeyUp, tea.KeyDown, tea.KeyLeft, tea.KeyRight,
 	tea.KeyShiftUp, tea.KeyShiftDown, tea.KeyShiftLeft, tea.KeyShiftRight,
@@ -242,10 +215,8 @@ var keyNames = func() map[string]bool {
 	return names
 }()
 
-// spaceKey is what Bubble Tea calls the space bar. A chord's keys are
-// separated by spaces, so that name cannot survive the encoding: bindings
-// spell the space bar "space" and arriving keys are translated to match,
-// which keeps it bindable instead of unwritable.
+// spaceKey is Bubble Tea's name for the space bar. Chords are space-separated,
+// so bindings spell it "space" and arriving keys are translated to match.
 const spaceKey = " "
 
 func normalizeKey(key string) string {
@@ -270,9 +241,8 @@ func parseKeySeq(seq string) (string, error) {
 		if r := []rune(key); len(r) == 1 && unicode.IsPrint(r[0]) {
 			continue
 		}
-		// Both hints name a mistake that would otherwise read as a key that
-		// simply never fires. Case matters — G and g are different keys — so a
-		// name that is only miscapitalized is worth saying out loud.
+		// Case matters (G and g differ), so a name that is only miscapitalized is
+		// worth saying out loud rather than reporting as unknown.
 		hint := ""
 		switch {
 		case keyNames[strings.ToLower(key)]:
@@ -322,21 +292,15 @@ func validateBindings(bindings map[keyAction][]string) []error {
 		}
 	}
 	slices.SortFunc(errs, func(a, b error) int { return strings.Compare(a.Error(), b.Error()) })
-	// One mistake, one sentence. An action that exists on both screens is
-	// checked on both, so a key it collides with produces the same complaint
-	// twice — which reads as two separate problems to fix.
+	// One mistake, one sentence: an action on both screens is checked on both.
 	return slices.CompactFunc(errs, func(a, b error) bool { return a.Error() == b.Error() })
 }
 
 // buildKeymap resolves a preset name and the user's per-action overrides into
 // a keymap. An override replaces that action's keys outright rather than
-// adding to them, so a user who moves an action doesn't have to also remember
-// to remove the key it used to be on; an empty list unbinds it.
-//
-// Errors never yield a half-applied keymap. A partially honored config is a
-// puzzle — some keys moved, some didn't, and nothing on screen says which —
-// so the returned keymap is the plain preset whenever anything is wrong, and
-// every reason is reported at once.
+// adding to them; an empty list unbinds it. Errors never yield a half-applied
+// keymap — a partly honored config is a puzzle nothing on screen explains — so
+// anything wrong returns the plain preset and reports every reason at once.
 func buildKeymap(preset string, overrides map[string][]string) (Keymap, []error) {
 	base, ok := presets[preset]
 	if !ok {
@@ -384,9 +348,8 @@ type Keymap struct {
 	prefix []map[string]bool
 }
 
-// newKeymap indexes a binding set for dispatch. It assumes the set has already
-// been through validate — an unvalidated one silently resolves ties by map
-// order, which is exactly the non-determinism validate exists to prevent.
+// newKeymap indexes a validated binding set for dispatch. An unvalidated one
+// resolves ties by map order, which is what validate exists to prevent.
 func newKeymap(bindings map[keyAction][]string) Keymap {
 	km := Keymap{
 		keys:   maps.Clone(bindings),
@@ -437,9 +400,8 @@ func (k Keymap) isPrefix(ctx keyContext, seq []string) bool {
 // keysFor returns an action's bound sequences.
 func (k Keymap) keysFor(act keyAction) []string { return k.resolved().keys[act] }
 
-// bound reports whether an action can be reached at all. The help bar asks
-// before advertising anything: a user who unbinds an action should stop being
-// told about it, not be told a lie.
+// bound reports whether an action can be reached at all, so the help bar can
+// stop advertising one the user unbound.
 func (k Keymap) bound(act keyAction) bool { return len(k.keysFor(act)) > 0 }
 
 // label renders every key bound to an action for the help bar and cheatsheet,
@@ -453,11 +415,8 @@ func (k Keymap) label(act keyAction) string {
 	return strings.Join(out, "/")
 }
 
-// pairLabel renders two opposed actions as one chip ("↑/↓"), using each
-// action's first binding. The help bar is width-constrained and up/down,
-// esc/q and their kin have always shared a chip there; showing every key of
-// both would double the bar's width to say the same thing. The cheatsheet,
-// which has the room, uses label and shows them all.
+// pairLabel renders two opposed actions as one chip ("↑/↓") from each one's
+// first binding, for the width-constrained help bar. The cheatsheet uses label.
 func (k Keymap) pairLabel(a, b keyAction) string {
 	first := func(act keyAction) string {
 		if seqs := k.keysFor(act); len(seqs) > 0 {
@@ -477,9 +436,8 @@ func (k Keymap) pairLabel(a, b keyAction) string {
 	return x + "/" + y
 }
 
-// displaySeq renders one binding for the screen: arrows as glyphs, and a
-// chord without the space that separates its keys in the config file, since
-// "gg" is how the user thinks of it and "g g" is only how it is written down.
+// displaySeq renders a binding for the screen: arrows as glyphs, and a chord
+// without the space that only separates its keys in the config file.
 func displaySeq(seq string) string {
 	var b strings.Builder
 	for _, key := range strings.Split(seq, " ") {

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -152,9 +152,42 @@ var defaultPreset = map[keyAction][]string{
 	actQuit:         {"q"},
 }
 
-// presets are the names accepted by `keys:` in the config file.
+// vimOverlay is what `keys: vim` changes, and it is deliberately short: j/k,
+// /, and y were already the vim spelling of themselves, so the preset is the
+// motions the default keymap had no answer for. Nothing is taken away —
+// home/end/pgup/pgdown keep working, because a preset that unbound them would
+// trade one set of habits for another rather than add to it.
+//
+// gg over g: the chord is what a vim user's fingers already do, and the
+// machinery to resolve it is the same machinery a config file needs anyway.
+var vimOverlay = map[keyAction][]string{
+	actTop:          {"g g", "home"},
+	actBottom:       {"G", "end"},
+	actPageUp:       {"ctrl+b", "pgup"},
+	actPageDown:     {"ctrl+f", "pgdown"},
+	actHalfPageUp:   {"ctrl+u"},
+	actHalfPageDown: {"ctrl+d"},
+}
+
+// presets are the names accepted by -keys and by `keys:` in the config file.
 var presets = map[string]map[keyAction][]string{
 	"default": defaultPreset,
+	"vim":     mergePreset(defaultPreset, vimOverlay),
+}
+
+func mergePreset(base, overlay map[keyAction][]string) map[keyAction][]string {
+	out := maps.Clone(base)
+	maps.Copy(out, overlay)
+	return out
+}
+
+// PresetKeymap returns a named preset's keymap, for -keys.
+func PresetKeymap(name string) (Keymap, error) {
+	km, errs := buildKeymap(name, nil)
+	if len(errs) > 0 {
+		return km, errs[0]
+	}
+	return km, nil
 }
 
 // presetNames lists the presets for error messages, in a stable order.
@@ -165,29 +198,31 @@ func presetNames() []string { return slices.Sorted(maps.Keys(presets)) }
 // each name rather than by copying the strings, so a binding can never be
 // written in a spelling that no keypress will ever match ("pgdn" for
 // "pgdown"). Printable single runes are accepted on top of these.
+//
+// Absent on purpose: ctrl+c (the terminal's own way out, and the second press
+// quits whatever quit is bound to), ctrl+h/ctrl+i/ctrl+j/ctrl+m (the same
+// bytes as backspace/tab/enter, so binding them would move a key the user did
+// not name), and ctrl+z (the shell's job control).
+var bindableKeyTypes = []tea.KeyType{
+	tea.KeyUp, tea.KeyDown, tea.KeyLeft, tea.KeyRight,
+	tea.KeyShiftUp, tea.KeyShiftDown, tea.KeyShiftLeft, tea.KeyShiftRight,
+	tea.KeyCtrlUp, tea.KeyCtrlDown, tea.KeyCtrlLeft, tea.KeyCtrlRight,
+	tea.KeyEnter, tea.KeyEsc, tea.KeyTab, tea.KeyShiftTab, tea.KeySpace,
+	tea.KeyBackspace, tea.KeyDelete, tea.KeyInsert,
+	tea.KeyHome, tea.KeyEnd, tea.KeyPgUp, tea.KeyPgDown,
+	tea.KeyCtrlHome, tea.KeyCtrlEnd, tea.KeyCtrlPgUp, tea.KeyCtrlPgDown,
+	tea.KeyCtrlA, tea.KeyCtrlB, tea.KeyCtrlD, tea.KeyCtrlE,
+	tea.KeyCtrlF, tea.KeyCtrlG, tea.KeyCtrlK, tea.KeyCtrlL,
+	tea.KeyCtrlN, tea.KeyCtrlO, tea.KeyCtrlP, tea.KeyCtrlQ,
+	tea.KeyCtrlR, tea.KeyCtrlS, tea.KeyCtrlT, tea.KeyCtrlU,
+	tea.KeyCtrlV, tea.KeyCtrlW, tea.KeyCtrlX, tea.KeyCtrlY,
+	tea.KeyF1, tea.KeyF2, tea.KeyF3, tea.KeyF4, tea.KeyF5, tea.KeyF6,
+	tea.KeyF7, tea.KeyF8, tea.KeyF9, tea.KeyF10, tea.KeyF11, tea.KeyF12,
+}
+
 var keyNames = func() map[string]bool {
-	types := []tea.KeyType{
-		tea.KeyUp, tea.KeyDown, tea.KeyLeft, tea.KeyRight,
-		tea.KeyShiftUp, tea.KeyShiftDown, tea.KeyShiftLeft, tea.KeyShiftRight,
-		tea.KeyCtrlUp, tea.KeyCtrlDown, tea.KeyCtrlLeft, tea.KeyCtrlRight,
-		tea.KeyEnter, tea.KeyEsc, tea.KeyTab, tea.KeyShiftTab, tea.KeySpace,
-		tea.KeyBackspace, tea.KeyDelete, tea.KeyInsert,
-		tea.KeyHome, tea.KeyEnd, tea.KeyPgUp, tea.KeyPgDown,
-		tea.KeyCtrlHome, tea.KeyCtrlEnd, tea.KeyCtrlPgUp, tea.KeyCtrlPgDown,
-		tea.KeyCtrlA, tea.KeyCtrlB, tea.KeyCtrlD, tea.KeyCtrlE,
-		tea.KeyCtrlF, tea.KeyCtrlG, tea.KeyCtrlK, tea.KeyCtrlL,
-		tea.KeyCtrlN, tea.KeyCtrlO, tea.KeyCtrlP, tea.KeyCtrlQ,
-		tea.KeyCtrlR, tea.KeyCtrlS, tea.KeyCtrlT, tea.KeyCtrlU,
-		tea.KeyCtrlV, tea.KeyCtrlW, tea.KeyCtrlX, tea.KeyCtrlY,
-		tea.KeyF1, tea.KeyF2, tea.KeyF3, tea.KeyF4, tea.KeyF5, tea.KeyF6,
-		tea.KeyF7, tea.KeyF8, tea.KeyF9, tea.KeyF10, tea.KeyF11, tea.KeyF12,
-	}
-	// Absent on purpose: ctrl+c (the terminal's own way out, and the second
-	// press quits whatever quit is bound to), ctrl+h/ctrl+i/ctrl+j/ctrl+m
-	// (the same bytes as backspace/tab/enter, so binding them would move a
-	// key the user did not name), and ctrl+z (the shell's job control).
-	names := make(map[string]bool, len(types))
-	for _, kt := range types {
+	names := make(map[string]bool, len(bindableKeyTypes))
+	for _, kt := range bindableKeyTypes {
 		names[tea.Key{Type: kt}.String()] = true
 	}
 	return names

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -1,0 +1,440 @@
+// Key bindings as data. One table drives three things that used to be three
+// hand-maintained copies of the same letters: what a key does, what the
+// contextual help bar advertises, and what the ? cheatsheet lists. A binding
+// can no longer exist without a help entry, or drift from the key that
+// actually runs it.
+
+package ui
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"unicode"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/heymaikol/network-doctor/internal/textsafe"
+)
+
+// keyAction is one rebindable thing the user can ask for. The zero value is
+// "no action", which is what an unbound key resolves to.
+type keyAction int
+
+const (
+	actNone keyAction = iota
+	actUp
+	actDown
+	actTop
+	actBottom
+	actPageUp
+	actPageDown
+	actHalfPageUp
+	actHalfPageDown
+	actOpen
+	actBack
+	actClearFilter
+	actCancelJob
+	actSwitchJob
+	actCopy
+	actSave
+	actFilter
+	actRestart
+	actSSH
+	actNetworkMap
+	actHelp
+	actQuit
+)
+
+// keyContext is the screen a binding applies to. The text-entry screens — the
+// restart prompt, the SSH form, the filter line — are deliberately absent:
+// every printable key there belongs to the input, so a binding on this table
+// would take a letter away from typing rather than give the user a shortcut.
+// The confirm gate is absent for the same reason in reverse: y/esc on a shown
+// command is a safety question, not a shortcut, and it stays where the muscle
+// memory of every other confirm prompt puts it.
+type keyContext int
+
+const (
+	ctxList keyContext = iota
+	ctxViewer
+	numContexts
+)
+
+// actionDef is an action's name in the config file and its cheatsheet line
+// per context. A context missing from desc is a context the action does not
+// exist in, which is also what makes config validation context-aware: binding
+// `filter` costs the viewer a key and the check list nothing.
+type actionDef struct {
+	act  keyAction
+	name string
+	desc map[keyContext]string
+}
+
+// actionDefs is in cheatsheet order, and the cheatsheet reads top to bottom as
+// movement, then output, then session.
+var actionDefs = []actionDef{
+	{actUp, "up", map[keyContext]string{
+		ctxList:   "previous check — or device on the network map",
+		ctxViewer: "scroll up",
+	}},
+	{actDown, "down", map[keyContext]string{
+		ctxList:   "next check — or device on the network map",
+		ctxViewer: "scroll down",
+	}},
+	{actTop, "top", map[keyContext]string{ctxViewer: "jump to top"}},
+	{actBottom, "bottom", map[keyContext]string{ctxViewer: "jump to bottom (re-enables follow)"}},
+	// Paging is viewer-only on purpose: the check list is rendered whole, so
+	// there is no page below the fold to move by — top/bottom already reach
+	// everything a page key could.
+	{actPageUp, "page-up", map[keyContext]string{ctxViewer: "page up"}},
+	{actPageDown, "page-down", map[keyContext]string{ctxViewer: "page down"}},
+	{actHalfPageUp, "half-page-up", map[keyContext]string{ctxViewer: "half page up"}},
+	{actHalfPageDown, "half-page-down", map[keyContext]string{ctxViewer: "half page down"}},
+	{actOpen, "open", map[keyContext]string{
+		ctxList: "full output — or set target on the network map",
+	}},
+	{actFilter, "filter", map[keyContext]string{ctxViewer: "filter lines"}},
+	{actCopy, "copy", map[keyContext]string{
+		ctxList:   "copy selected portal URL, otherwise report",
+		ctxViewer: "copy output (filtered if a filter is on)",
+	}},
+	{actSave, "save", map[keyContext]string{
+		ctxList:   "save report",
+		ctxViewer: "save output (filtered if a filter is on)",
+	}},
+	{actSwitchJob, "switch-job", map[keyContext]string{
+		ctxList:   "switch job",
+		ctxViewer: "switch job",
+	}},
+	{actCancelJob, "cancel-job", map[keyContext]string{ctxList: "cancel the focused job"}},
+	{actNetworkMap, "network-map", map[keyContext]string{ctxList: "toggle network map"}},
+	{actRestart, "restart", map[keyContext]string{ctxList: "restart with a new target"}},
+	{actSSH, "ssh", map[keyContext]string{ctxList: "ssh to a host — hands the terminal to ssh"}},
+	// Two actions rather than one so that a filtered viewer keeps its
+	// two-step exit: the key that clears a filter is not the key that leaves
+	// with one still applied, and each stays rebindable on its own.
+	{actClearFilter, "clear-filter", map[keyContext]string{ctxViewer: "clear the filter, or back when none is set"}},
+	{actBack, "back", map[keyContext]string{ctxViewer: "back"}},
+	{actHelp, "help", map[keyContext]string{ctxList: "full-screen key cheatsheet"}},
+	{actQuit, "quit", map[keyContext]string{ctxList: "quit"}},
+}
+
+// defaultPreset is the historical keymap: every letter netdoc has ever
+// answered to, plus the list jump keys that had no binding before.
+var defaultPreset = map[keyAction][]string{
+	actUp:           {"up", "k"},
+	actDown:         {"down", "j"},
+	actTop:          {"home"},
+	actBottom:       {"end"},
+	actPageUp:       {"pgup"},
+	actPageDown:     {"pgdown"},
+	actHalfPageUp:   nil,
+	actHalfPageDown: nil,
+	actOpen:         {"enter"},
+	actBack:         {"q"},
+	actClearFilter:  {"esc"},
+	actCancelJob:    {"esc"},
+	actSwitchJob:    {"tab"},
+	actCopy:         {"y"},
+	actSave:         {"w"},
+	actFilter:       {"/"},
+	actRestart:      {"r"},
+	actSSH:          {"S"},
+	actNetworkMap:   {"v"},
+	actHelp:         {"?"},
+	actQuit:         {"q"},
+}
+
+// presets are the names accepted by `keys:` in the config file.
+var presets = map[string]map[keyAction][]string{
+	"default": defaultPreset,
+}
+
+// presetNames lists the presets for error messages, in a stable order.
+func presetNames() []string { return slices.Sorted(maps.Keys(presets)) }
+
+// keyNames is every key name a binding may use, spelled the way Bubble Tea
+// spells it when the key arrives — the set is built by asking Bubble Tea for
+// each name rather than by copying the strings, so a binding can never be
+// written in a spelling that no keypress will ever match ("pgdn" for
+// "pgdown"). Printable single runes are accepted on top of these.
+var keyNames = func() map[string]bool {
+	types := []tea.KeyType{
+		tea.KeyUp, tea.KeyDown, tea.KeyLeft, tea.KeyRight,
+		tea.KeyShiftUp, tea.KeyShiftDown, tea.KeyShiftLeft, tea.KeyShiftRight,
+		tea.KeyCtrlUp, tea.KeyCtrlDown, tea.KeyCtrlLeft, tea.KeyCtrlRight,
+		tea.KeyEnter, tea.KeyEsc, tea.KeyTab, tea.KeyShiftTab, tea.KeySpace,
+		tea.KeyBackspace, tea.KeyDelete, tea.KeyInsert,
+		tea.KeyHome, tea.KeyEnd, tea.KeyPgUp, tea.KeyPgDown,
+		tea.KeyCtrlHome, tea.KeyCtrlEnd, tea.KeyCtrlPgUp, tea.KeyCtrlPgDown,
+		tea.KeyCtrlA, tea.KeyCtrlB, tea.KeyCtrlD, tea.KeyCtrlE,
+		tea.KeyCtrlF, tea.KeyCtrlG, tea.KeyCtrlK, tea.KeyCtrlL,
+		tea.KeyCtrlN, tea.KeyCtrlO, tea.KeyCtrlP, tea.KeyCtrlQ,
+		tea.KeyCtrlR, tea.KeyCtrlS, tea.KeyCtrlT, tea.KeyCtrlU,
+		tea.KeyCtrlV, tea.KeyCtrlW, tea.KeyCtrlX, tea.KeyCtrlY,
+		tea.KeyF1, tea.KeyF2, tea.KeyF3, tea.KeyF4, tea.KeyF5, tea.KeyF6,
+		tea.KeyF7, tea.KeyF8, tea.KeyF9, tea.KeyF10, tea.KeyF11, tea.KeyF12,
+	}
+	// Absent on purpose: ctrl+c (the terminal's own way out, and the second
+	// press quits whatever quit is bound to), ctrl+h/ctrl+i/ctrl+j/ctrl+m
+	// (the same bytes as backspace/tab/enter, so binding them would move a
+	// key the user did not name), and ctrl+z (the shell's job control).
+	names := make(map[string]bool, len(types))
+	for _, kt := range types {
+		names[tea.Key{Type: kt}.String()] = true
+	}
+	return names
+}()
+
+// spaceKey is what Bubble Tea calls the space bar. A chord's keys are
+// separated by spaces, so that name cannot survive the encoding: bindings
+// spell the space bar "space" and arriving keys are translated to match,
+// which keeps it bindable instead of unwritable.
+const spaceKey = " "
+
+func normalizeKey(key string) string {
+	if key == spaceKey {
+		return "space"
+	}
+	return key
+}
+
+// parseKeySeq turns one config binding into its canonical form, e.g.
+// "g  g" → "g g". A chord's keys are separated by spaces; a key that is not a
+// single printable rune must be one of the names above.
+func parseKeySeq(seq string) (string, error) {
+	keys := strings.Fields(seq)
+	if len(keys) == 0 {
+		return "", fmt.Errorf("empty key")
+	}
+	for _, key := range keys {
+		if key == "space" || keyNames[key] {
+			continue
+		}
+		if r := []rune(key); len(r) == 1 && unicode.IsPrint(r[0]) {
+			continue
+		}
+		hint := ""
+		if len([]rune(key)) > 1 {
+			// The commonest mistake by far, and the one that would otherwise
+			// look like a key that simply never fires.
+			hint = " (a chord is written with spaces, e.g. \"g g\")"
+		}
+		return "", fmt.Errorf("unknown key %q%s", textsafe.Clean(key), hint)
+	}
+	return strings.Join(keys, " "), nil
+}
+
+// validateBindings reports everything wrong with a binding set, all at once —
+// a config with three mistakes should take one edit to fix, not three runs.
+func validateBindings(bindings map[keyAction][]string) []error {
+	var errs []error
+	toolKeys := allToolKeys()
+	// Indexed by context, so the same key may mean one thing in the check
+	// list and another in the viewer, as esc always has.
+	owner := make([]map[string]string, numContexts)
+	seqs := make([]map[string]string, numContexts)
+	for ctx := range numContexts {
+		owner[ctx], seqs[ctx] = map[string]string{}, map[string]string{}
+	}
+	for _, def := range actionDefs {
+		for _, seq := range bindings[def.act] {
+			for ctx := range def.desc {
+				if held := owner[ctx][seq]; held != "" {
+					errs = append(errs, fmt.Errorf("%q is bound to both %s and %s", displaySeq(seq), held, def.name))
+					continue
+				}
+				owner[ctx][seq] = def.name
+				seqs[ctx][seq] = def.name
+			}
+			if slices.Contains(toolKeys, strings.Fields(seq)[0]) && def.desc[ctxList] != "" {
+				errs = append(errs, fmt.Errorf("%s is bound to %q, which the toolbox uses to run a tool", def.name, displaySeq(seq)))
+			}
+		}
+	}
+	// A binding buried under a chord that starts with it would never fire:
+	// the first key would always wait for the second.
+	for ctx := range numContexts {
+		for seq, name := range seqs[ctx] {
+			for other, otherName := range seqs[ctx] {
+				if seq != other && strings.HasPrefix(other, seq+" ") {
+					errs = append(errs, fmt.Errorf("%s is bound to %q, which is the start of %s's %q", name, displaySeq(seq), otherName, displaySeq(other)))
+				}
+			}
+		}
+	}
+	slices.SortFunc(errs, func(a, b error) int { return strings.Compare(a.Error(), b.Error()) })
+	return errs
+}
+
+// buildKeymap resolves a preset name and the user's per-action overrides into
+// a keymap. An override replaces that action's keys outright rather than
+// adding to them, so a user who moves an action doesn't have to also remember
+// to remove the key it used to be on; an empty list unbinds it.
+//
+// Errors never yield a half-applied keymap. A partially honored config is a
+// puzzle — some keys moved, some didn't, and nothing on screen says which —
+// so the returned keymap is the plain preset whenever anything is wrong, and
+// every reason is reported at once.
+func buildKeymap(preset string, overrides map[string][]string) (Keymap, []error) {
+	base, ok := presets[preset]
+	if !ok {
+		return defaultKeymap, []error{fmt.Errorf("unknown key preset %q: pick one of %s",
+			textsafe.Clean(preset), strings.Join(presetNames(), ", "))}
+	}
+	byName := make(map[string]keyAction, len(actionDefs))
+	for _, def := range actionDefs {
+		byName[def.name] = def.act
+	}
+	bindings, errs := maps.Clone(base), []error(nil)
+	for _, name := range slices.Sorted(maps.Keys(overrides)) {
+		act, ok := byName[name]
+		if !ok {
+			errs = append(errs, fmt.Errorf("unknown action %q", textsafe.Clean(name)))
+			continue
+		}
+		parsed := make([]string, 0, len(overrides[name]))
+		for _, seq := range overrides[name] {
+			canonical, err := parseKeySeq(seq)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("%s: %w", name, err))
+				continue
+			}
+			parsed = append(parsed, canonical)
+		}
+		bindings[act] = parsed
+	}
+	errs = append(errs, validateBindings(bindings)...)
+	if len(errs) > 0 {
+		return newKeymap(base), errs
+	}
+	return newKeymap(bindings), nil
+}
+
+// Keymap resolves keys to actions. The zero value is the default keymap, so
+// every model that never asked for one — tests included — behaves exactly as
+// it did before bindings became configurable.
+type Keymap struct {
+	// keys is action → bound sequences, in the order they should be
+	// advertised. A sequence is its keys joined by spaces ("g g").
+	keys map[keyAction][]string
+	// byKey and prefix are the dispatch indexes, one entry per context.
+	byKey  []map[string]keyAction
+	prefix []map[string]bool
+}
+
+// newKeymap indexes a binding set for dispatch. It assumes the set has already
+// been through validate — an unvalidated one silently resolves ties by map
+// order, which is exactly the non-determinism validate exists to prevent.
+func newKeymap(bindings map[keyAction][]string) Keymap {
+	km := Keymap{
+		keys:   maps.Clone(bindings),
+		byKey:  make([]map[string]keyAction, numContexts),
+		prefix: make([]map[string]bool, numContexts),
+	}
+	for ctx := range numContexts {
+		km.byKey[ctx] = map[string]keyAction{}
+		km.prefix[ctx] = map[string]bool{}
+	}
+	for _, def := range actionDefs {
+		for ctx := range def.desc {
+			for _, seq := range bindings[def.act] {
+				km.byKey[ctx][seq] = def.act
+				keys := strings.Split(seq, " ")
+				for i := 1; i < len(keys); i++ {
+					km.prefix[ctx][strings.Join(keys[:i], " ")] = true
+				}
+			}
+		}
+	}
+	return km
+}
+
+var defaultKeymap = newKeymap(defaultPreset)
+
+// resolved substitutes the default keymap for the zero value.
+func (k Keymap) resolved() Keymap {
+	if k.keys == nil {
+		return defaultKeymap
+	}
+	return k
+}
+
+// lookup resolves a complete key sequence in ctx.
+func (k Keymap) lookup(ctx keyContext, seq []string) (keyAction, bool) {
+	act, ok := k.resolved().byKey[ctx][strings.Join(seq, " ")]
+	return act, ok
+}
+
+// isPrefix reports whether seq is the unfinished start of a longer binding —
+// the "g" of "g g", which must wait for the next key rather than fall through
+// to the tool hotkeys.
+func (k Keymap) isPrefix(ctx keyContext, seq []string) bool {
+	return k.resolved().prefix[ctx][strings.Join(seq, " ")]
+}
+
+// keysFor returns an action's bound sequences.
+func (k Keymap) keysFor(act keyAction) []string { return k.resolved().keys[act] }
+
+// bound reports whether an action can be reached at all. The help bar asks
+// before advertising anything: a user who unbinds an action should stop being
+// told about it, not be told a lie.
+func (k Keymap) bound(act keyAction) bool { return len(k.keysFor(act)) > 0 }
+
+// label renders every key bound to an action for the help bar and cheatsheet,
+// e.g. "↑/k" or "gg/home". Empty when the action is unbound.
+func (k Keymap) label(act keyAction) string {
+	seqs := k.keysFor(act)
+	out := make([]string, 0, len(seqs))
+	for _, seq := range seqs {
+		out = append(out, displaySeq(seq))
+	}
+	return strings.Join(out, "/")
+}
+
+// pairLabel renders two opposed actions as one chip ("↑/↓"), using each
+// action's first binding. The help bar is width-constrained and up/down,
+// esc/q and their kin have always shared a chip there; showing every key of
+// both would double the bar's width to say the same thing. The cheatsheet,
+// which has the room, uses label and shows them all.
+func (k Keymap) pairLabel(a, b keyAction) string {
+	first := func(act keyAction) string {
+		if seqs := k.keysFor(act); len(seqs) > 0 {
+			return displaySeq(seqs[0])
+		}
+		return ""
+	}
+	x, y := first(a), first(b)
+	switch {
+	case x == "" && y == "":
+		return ""
+	case x == "":
+		return y
+	case y == "":
+		return x
+	}
+	return x + "/" + y
+}
+
+// displaySeq renders one binding for the screen: arrows as glyphs, and a
+// chord without the space that separates its keys in the config file, since
+// "gg" is how the user thinks of it and "g g" is only how it is written down.
+func displaySeq(seq string) string {
+	var b strings.Builder
+	for _, key := range strings.Split(seq, " ") {
+		switch key {
+		case "up":
+			b.WriteString("↑")
+		case "down":
+			b.WriteString("↓")
+		case "left":
+			b.WriteString("←")
+		case "right":
+			b.WriteString("→")
+		default:
+			b.WriteString(key)
+		}
+	}
+	return b.String()
+}

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -256,11 +256,15 @@ func parseKeySeq(seq string) (string, error) {
 		if r := []rune(key); len(r) == 1 && unicode.IsPrint(r[0]) {
 			continue
 		}
+		// Both hints name a mistake that would otherwise read as a key that
+		// simply never fires. Case matters — G and g are different keys — so a
+		// name that is only miscapitalized is worth saying out loud.
 		hint := ""
-		if len([]rune(key)) > 1 {
-			// The commonest mistake by far, and the one that would otherwise
-			// look like a key that simply never fires.
-			hint = " (a chord is written with spaces, e.g. \"g g\")"
+		switch {
+		case keyNames[strings.ToLower(key)]:
+			hint = fmt.Sprintf(" (named keys are lower case: %q)", strings.ToLower(key))
+		case len([]rune(key)) > 1:
+			hint = ` (a chord is written with spaces, e.g. "g g")`
 		}
 		return "", fmt.Errorf("unknown key %q%s", textsafe.Clean(key), hint)
 	}

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -276,12 +276,11 @@ func parseKeySeq(seq string) (string, error) {
 func validateBindings(bindings map[keyAction][]string) []error {
 	var errs []error
 	toolKeys := allToolKeys()
-	// Indexed by context, so the same key may mean one thing in the check
-	// list and another in the viewer, as esc always has.
+	// owner is indexed by context, so the same key may mean one thing in the
+	// check list and another in the viewer, as esc always has.
 	owner := make([]map[string]string, numContexts)
-	seqs := make([]map[string]string, numContexts)
 	for ctx := range numContexts {
-		owner[ctx], seqs[ctx] = map[string]string{}, map[string]string{}
+		owner[ctx] = map[string]string{}
 	}
 	for _, def := range actionDefs {
 		for _, seq := range bindings[def.act] {
@@ -291,7 +290,6 @@ func validateBindings(bindings map[keyAction][]string) []error {
 					continue
 				}
 				owner[ctx][seq] = def.name
-				seqs[ctx][seq] = def.name
 			}
 			if slices.Contains(toolKeys, strings.Fields(seq)[0]) && def.desc[ctxList] != "" {
 				errs = append(errs, fmt.Errorf("%s is bound to %q, which the toolbox uses to run a tool", def.name, displaySeq(seq)))
@@ -301,8 +299,8 @@ func validateBindings(bindings map[keyAction][]string) []error {
 	// A binding buried under a chord that starts with it would never fire:
 	// the first key would always wait for the second.
 	for ctx := range numContexts {
-		for seq, name := range seqs[ctx] {
-			for other, otherName := range seqs[ctx] {
+		for seq, name := range owner[ctx] {
+			for other, otherName := range owner[ctx] {
 				if seq != other && strings.HasPrefix(other, seq+" ") {
 					errs = append(errs, fmt.Errorf("%s is bound to %q, which is the start of %s's %q", name, displaySeq(seq), otherName, displaySeq(other)))
 				}

--- a/internal/ui/keymap.go
+++ b/internal/ui/keymap.go
@@ -122,17 +122,29 @@ var actionDefs = []actionDef{
 	// with one still applied, and each stays rebindable on its own.
 	{actClearFilter, "clear-filter", map[keyContext]string{ctxViewer: "clear the filter, or back when none is set"}},
 	{actBack, "back", map[keyContext]string{ctxViewer: "back"}},
-	{actHelp, "help", map[keyContext]string{ctxList: "full-screen key cheatsheet"}},
+	// Reachable from the output viewer too: a tool's full output is exactly
+	// where someone wonders what a key does, and it used to be the one screen
+	// that could not answer.
+	{actHelp, "help", map[keyContext]string{
+		ctxList:   "full-screen key cheatsheet",
+		ctxViewer: "full-screen key cheatsheet",
+	}},
 	{actQuit, "quit", map[keyContext]string{ctxList: "quit"}},
 }
 
 // defaultPreset is the historical keymap: every letter netdoc has ever
-// answered to, plus the list jump keys that had no binding before.
+// answered to, plus the jump keys that had no binding before.
+//
+// gg and G are here rather than in the vim preset because they cost a
+// non-vim user nothing — both keys did nothing at all before, and a lone g
+// still lets the key after it behave exactly as it would have. A jump to the
+// top of a long route table should not require a config file. home and end
+// are listed first, so the help bar advertises the spelling everyone knows.
 var defaultPreset = map[keyAction][]string{
 	actUp:           {"up", "k"},
 	actDown:         {"down", "j"},
-	actTop:          {"home"},
-	actBottom:       {"end"},
+	actTop:          {"home", "g g"},
+	actBottom:       {"end", "G"},
 	actPageUp:       {"pgup"},
 	actPageDown:     {"pgdown"},
 	actHalfPageUp:   nil,
@@ -153,13 +165,15 @@ var defaultPreset = map[keyAction][]string{
 }
 
 // vimOverlay is what `keys: vim` changes, and it is deliberately short: j/k,
-// /, and y were already the vim spelling of themselves, so the preset is the
-// motions the default keymap had no answer for. Nothing is taken away —
-// home/end/pgup/pgdown keep working, because a preset that unbound them would
-// trade one set of habits for another rather than add to it.
+// /, y, gg and G are already in the default keymap, so what is left is the
+// ctrl-motions — the ones that would cost a non-vim user a key they might
+// want for something else. Nothing is taken away: pgup/pgdown keep working,
+// because a preset that unbound them would trade one set of habits for
+// another rather than add to it.
 //
-// gg over g: the chord is what a vim user's fingers already do, and the
-// machinery to resolve it is the same machinery a config file needs anyway.
+// top and bottom are relisted only to reorder them. The keys are the same
+// ones the default binds; putting vim's spelling first is what makes the help
+// bar read gg/G instead of home/end, so the preset says out loud that it is on.
 var vimOverlay = map[keyAction][]string{
 	actTop:          {"g g", "home"},
 	actBottom:       {"G", "end"},
@@ -308,7 +322,10 @@ func validateBindings(bindings map[keyAction][]string) []error {
 		}
 	}
 	slices.SortFunc(errs, func(a, b error) int { return strings.Compare(a.Error(), b.Error()) })
-	return errs
+	// One mistake, one sentence. An action that exists on both screens is
+	// checked on both, so a key it collides with produces the same complaint
+	// twice — which reads as two separate problems to fix.
+	return slices.CompactFunc(errs, func(a, b error) bool { return a.Error() == b.Error() })
 }
 
 // buildKeymap resolves a preset name and the user's per-action overrides into

--- a/internal/ui/keymap_test.go
+++ b/internal/ui/keymap_test.go
@@ -251,6 +251,30 @@ func TestHelpFollowsRebinding(t *testing.T) {
 	}
 }
 
+// A rebound key can be much longer than the one it replaced, and the
+// cheatsheet's key column has to grow with it instead of running the label
+// into its description.
+func TestCheatsheetKeyColumnFitsLongLabels(t *testing.T) {
+	km, errs := buildKeymap("default", map[string][]string{"help": {"ctrl+x", "f12", "?"}})
+	if len(errs) > 0 {
+		t.Fatalf("rebind: %v", errs)
+	}
+	m := newModel(nil, false)
+	m.keys, m.width, m.height = km, 100, 40
+	m.helping = true
+	want := km.label(actHelp)
+	for _, line := range strings.Split(m.View(), "\n") {
+		if !strings.Contains(line, want) {
+			continue
+		}
+		if !strings.Contains(line, want+"  ") {
+			t.Errorf("cheatsheet row %q runs the key label into its description", line)
+		}
+		return
+	}
+	t.Errorf("no cheatsheet row for %q:\n%s", want, m.View())
+}
+
 // An unbound action is not advertised: a help bar offering a key that does
 // nothing is worse than a shorter help bar.
 func TestUnboundActionsVanishFromHelp(t *testing.T) {

--- a/internal/ui/keymap_test.go
+++ b/internal/ui/keymap_test.go
@@ -1,0 +1,188 @@
+// The keymap's structural invariants — the ones a rebinding user relies on
+// without knowing they exist: one action per key per screen, no binding buried
+// under a chord that starts with it, and nothing shadowing a tool hotkey.
+
+package ui
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/heymaikol/network-doctor/internal/diagnostic"
+)
+
+// Every shipped preset has to survive the same validation a user's config
+// does; a preset that couldn't be written by hand would be a keymap the
+// validator calls impossible.
+func TestPresetsValidate(t *testing.T) {
+	for name, preset := range presets {
+		if errs := validateBindings(preset); len(errs) > 0 {
+			t.Errorf("preset %q: %v", name, errs)
+		}
+	}
+}
+
+// The cheatsheet and the help bar both read descriptions out of actionDefs, so
+// an action missing from that table is an action nobody can discover.
+func TestEveryActionIsDescribed(t *testing.T) {
+	seen := map[keyAction]bool{}
+	for _, def := range actionDefs {
+		if seen[def.act] {
+			t.Errorf("action %q listed twice", def.name)
+		}
+		if len(def.desc) == 0 {
+			t.Errorf("action %q describes no context", def.name)
+		}
+		seen[def.act] = true
+	}
+	for act := range defaultPreset {
+		if !seen[act] {
+			t.Errorf("action %d is bound by the default preset but has no actionDef", act)
+		}
+	}
+	for act := actNone + 1; act <= actQuit; act++ {
+		if !seen[act] {
+			t.Errorf("action %d has no actionDef", act)
+		}
+	}
+}
+
+// A chord is resolved key by key, and the key that ends a dead chord still
+// gets its own turn — otherwise a stray prefix would eat the keystroke after
+// it, which reads as the app dropping input.
+func TestChordResolution(t *testing.T) {
+	km, errs := buildKeymap("default", map[string][]string{"top": {"g g"}})
+	if len(errs) > 0 {
+		t.Fatalf("chord binding: %v", errs)
+	}
+	m := newModel(nil, false)
+	m.keys = km
+
+	act, pending := m.resolveKey(ctxViewer, "g")
+	if act != actNone || !slices.Equal(pending, []string{"g"}) {
+		t.Fatalf("first g = (%d, %v), want (none, [g])", act, pending)
+	}
+	m.pendingKeys = pending
+	if act, pending := m.resolveKey(ctxViewer, "g"); act != actTop || pending != nil {
+		t.Fatalf("gg = (%d, %v), want (top, nil)", act, pending)
+	}
+	// g then an unrelated key: the chord dies, the key still runs.
+	if act, pending := m.resolveKey(ctxViewer, "/"); act != actFilter || pending != nil {
+		t.Fatalf("g then / = (%d, %v), want (filter, nil)", act, pending)
+	}
+	// The chord belongs to the viewer, so the same keys in the check list
+	// resolve to nothing at all rather than to a prefix that waits forever.
+	m.pendingKeys = nil
+	if act, pending := m.resolveKey(ctxList, "g"); act != actNone || pending != nil {
+		t.Fatalf("g in the list = (%d, %v), want (none, nil)", act, pending)
+	}
+}
+
+// A chord in flight launches nothing, and the key that ends an unfinished one
+// behaves exactly as it would have if the prefix had never been typed — an
+// abandoned chord costs the user nothing, in either direction.
+func TestChordHoldsTheToolboxThenReleasesIt(t *testing.T) {
+	km, errs := buildKeymap("default", map[string][]string{"help": {"g g"}})
+	if len(errs) > 0 {
+		t.Fatalf("chord binding: %v", errs)
+	}
+	m := newModel(mustTarget(t, "example.com"), true)
+	m.keys = km
+	u, _ := m.handleKey(keyMsg("g"))
+	m = u.(model)
+	if !slices.Equal(m.pendingKeys, []string{"g"}) {
+		t.Fatalf("pendingKeys = %v, want [g]", m.pendingKeys)
+	}
+	if m.confirmTool != nil || m.cur.name != "" {
+		t.Fatalf("g started something: confirm=%v job=%q", m.confirmTool, m.cur.name)
+	}
+	// "n" is nmap's letter. It does not complete the chord, so the chord ends
+	// and n gets the turn it would have had on its own — the confirm gate,
+	// never a launch.
+	u, _ = m.handleKey(keyMsg("n"))
+	m = u.(model)
+	if m.pendingKeys != nil {
+		t.Fatalf("pendingKeys = %v after the chord died, want nil", m.pendingKeys)
+	}
+	if m.confirmTool == nil {
+		t.Fatal("n did not reach the port-scan gate after the chord ended")
+	}
+	// The completed chord runs its action instead, and never the tool.
+	m.confirmTool, m.pendingKeys = nil, []string{"g"}
+	u, _ = m.handleKey(keyMsg("g"))
+	if !u.(model).helping {
+		t.Fatal("gg did not open the cheatsheet")
+	}
+}
+
+// The help bar and cheatsheet must show the keys that actually run, not the
+// ones the defaults used to use.
+func TestHelpFollowsRebinding(t *testing.T) {
+	km, errs := buildKeymap("default", map[string][]string{"quit": {"Q"}, "restart": {"R"}})
+	if len(errs) > 0 {
+		t.Fatalf("rebind: %v", errs)
+	}
+	m := newModel(mustTarget(t, "example.com"), false)
+	m.keys = km
+	help := m.helpView(false)
+	if !strings.Contains(help, "Q") || !strings.Contains(help, "R") {
+		t.Errorf("help bar = %q, want the rebound keys", help)
+	}
+	m.helping = true
+	if overlay := m.View(); !strings.Contains(overlay, "Q") || !strings.Contains(overlay, "R") {
+		t.Errorf("cheatsheet = %q, want the rebound keys", overlay)
+	}
+	// And the rebound key has to work.
+	u, _ := m.handleKey(keyMsg("R"))
+	if !u.(model).entering {
+		t.Error("R did not open the restart prompt")
+	}
+}
+
+// An unbound action is not advertised: a help bar offering a key that does
+// nothing is worse than a shorter help bar.
+func TestUnboundActionsVanishFromHelp(t *testing.T) {
+	km, errs := buildKeymap("default", map[string][]string{"network-map": {}})
+	if len(errs) > 0 {
+		t.Fatalf("unbind: %v", errs)
+	}
+	m := newModel(nil, false)
+	m.keys = km
+	if help := m.helpView(false); strings.Contains(help, "network map") {
+		t.Errorf("help bar = %q, want no network map chip", help)
+	}
+	if km.bound(actNetworkMap) {
+		t.Error("network-map still reports as bound")
+	}
+}
+
+// allToolKeys is hand-written, so it needs a guard that walks the real
+// toolbox: a new drill-down tool must not become bindable by accident.
+func TestAllToolKeysMatchesTheToolbox(t *testing.T) {
+	targets := []*diagnostic.Target{
+		nil,
+		mustTarget(t, "example.com"),
+		mustTarget(t, "example.com:22"),
+		mustTarget(t, "example.com:25"),
+		mustTarget(t, "example.com:80"),
+		mustTarget(t, "1.1.1.1:443"),
+	}
+	found := map[string]bool{}
+	for _, goos := range []string{"linux", "darwin", "windows"} {
+		for _, tgt := range targets {
+			for _, tool := range toolsFor(tgt, goos, toolBind{}) {
+				found[tool.Key] = true
+			}
+		}
+	}
+	for _, key := range allToolKeys() {
+		if !found[key] {
+			t.Errorf("allToolKeys lists %q, which no tool uses", key)
+		}
+		delete(found, key)
+	}
+	for key := range found {
+		t.Errorf("tool key %q is missing from allToolKeys, so a binding could shadow it", key)
+	}
+}

--- a/internal/ui/keymap_test.go
+++ b/internal/ui/keymap_test.go
@@ -71,11 +71,15 @@ func TestChordResolution(t *testing.T) {
 	if act, pending := m.resolveKey(ctxViewer, "/"); act != actFilter || pending != nil {
 		t.Fatalf("g then / = (%d, %v), want (filter, nil)", act, pending)
 	}
-	// The chord belongs to the viewer, so the same keys in the check list
-	// resolve to nothing at all rather than to a prefix that waits forever.
+	// top exists in both screens, so its chord is live in both.
 	m.pendingKeys = nil
-	if act, pending := m.resolveKey(ctxList, "g"); act != actNone || pending != nil {
-		t.Fatalf("g in the list = (%d, %v), want (none, nil)", act, pending)
+	act, pending = m.resolveKey(ctxList, "g")
+	if act != actNone || !slices.Equal(pending, []string{"g"}) {
+		t.Fatalf("first g in the list = (%d, %v), want (none, [g])", act, pending)
+	}
+	m.pendingKeys = pending
+	if act, pending := m.resolveKey(ctxList, "g"); act != actTop || pending != nil {
+		t.Fatalf("gg in the list = (%d, %v), want (top, nil)", act, pending)
 	}
 }
 

--- a/internal/ui/keymap_test.go
+++ b/internal/ui/keymap_test.go
@@ -101,19 +101,19 @@ func TestChordResolution(t *testing.T) {
 // behaves exactly as it would have if the prefix had never been typed — an
 // abandoned chord costs the user nothing, in either direction.
 func TestChordHoldsTheToolboxThenReleasesIt(t *testing.T) {
-	km, errs := buildKeymap("default", map[string][]string{"help": {"g g"}})
+	km, errs := buildKeymap("default", map[string][]string{"help": {"z z"}})
 	if len(errs) > 0 {
 		t.Fatalf("chord binding: %v", errs)
 	}
 	m := newModel(mustTarget(t, "example.com"), true)
 	m.keys = km
-	u, _ := m.handleKey(keyMsg("g"))
+	u, _ := m.handleKey(keyMsg("z"))
 	m = u.(model)
-	if !slices.Equal(m.pendingKeys, []string{"g"}) {
-		t.Fatalf("pendingKeys = %v, want [g]", m.pendingKeys)
+	if !slices.Equal(m.pendingKeys, []string{"z"}) {
+		t.Fatalf("pendingKeys = %v, want [z]", m.pendingKeys)
 	}
 	if m.confirmTool != nil || m.cur.name != "" {
-		t.Fatalf("g started something: confirm=%v job=%q", m.confirmTool, m.cur.name)
+		t.Fatalf("z started something: confirm=%v job=%q", m.confirmTool, m.cur.name)
 	}
 	// "n" is nmap's letter. It does not complete the chord, so the chord ends
 	// and n gets the turn it would have had on its own — the confirm gate,
@@ -127,10 +127,10 @@ func TestChordHoldsTheToolboxThenReleasesIt(t *testing.T) {
 		t.Fatal("n did not reach the port-scan gate after the chord ended")
 	}
 	// The completed chord runs its action instead, and never the tool.
-	m.confirmTool, m.pendingKeys = nil, []string{"g"}
-	u, _ = m.handleKey(keyMsg("g"))
+	m.confirmTool, m.pendingKeys = nil, []string{"z"}
+	u, _ = m.handleKey(keyMsg("z"))
 	if !u.(model).helping {
-		t.Fatal("gg did not open the cheatsheet")
+		t.Fatal("zz did not open the cheatsheet")
 	}
 }
 

--- a/internal/ui/keymap_test.go
+++ b/internal/ui/keymap_test.go
@@ -5,12 +5,26 @@
 package ui
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/heymaikol/network-doctor/internal/diagnostic"
 )
+
+// keyPress builds the message a real terminal would send for a binding's key
+// name, so a test that says ctrl+d exercises the same path ctrl+d takes.
+func keyPress(name string) tea.KeyMsg {
+	for _, kt := range bindableKeyTypes {
+		if (tea.Key{Type: kt}).String() == name {
+			return tea.KeyMsg{Type: kt}
+		}
+	}
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(name)}
+}
 
 // Every shipped preset has to survive the same validation a user's config
 // does; a preset that couldn't be written by hand would be a keymap the
@@ -117,6 +131,99 @@ func TestChordHoldsTheToolboxThenReleasesIt(t *testing.T) {
 	u, _ = m.handleKey(keyMsg("g"))
 	if !u.(model).helping {
 		t.Fatal("gg did not open the cheatsheet")
+	}
+}
+
+// The vim preset's whole point is the motions, so each one is pinned against
+// the screen it moves — and against the default keys it must not have taken
+// away on its way in.
+func TestVimPresetMotions(t *testing.T) {
+	km, err := PresetKeymap("vim")
+	if err != nil {
+		t.Fatalf("PresetKeymap(vim): %v", err)
+	}
+	m := newModel(mustTarget(t, "example.com"), false)
+	m.keys = km
+	tests := []struct {
+		keys []string
+		ctx  keyContext
+		want keyAction
+	}{
+		{[]string{"g", "g"}, ctxViewer, actTop},
+		{[]string{"g", "g"}, ctxList, actTop},
+		{[]string{"G"}, ctxViewer, actBottom},
+		{[]string{"G"}, ctxList, actBottom},
+		{[]string{"ctrl+d"}, ctxViewer, actHalfPageDown},
+		{[]string{"ctrl+u"}, ctxViewer, actHalfPageUp},
+		{[]string{"ctrl+f"}, ctxViewer, actPageDown},
+		{[]string{"ctrl+b"}, ctxViewer, actPageUp},
+		{[]string{"j"}, ctxViewer, actDown},
+		{[]string{"k"}, ctxList, actUp},
+		// Kept, not replaced: the preset adds motions, it doesn't evict the
+		// keys a non-vim user in the same terminal already knows.
+		{[]string{"home"}, ctxList, actTop},
+		{[]string{"end"}, ctxViewer, actBottom},
+		{[]string{"pgdown"}, ctxViewer, actPageDown},
+		{[]string{"down"}, ctxList, actDown},
+		{[]string{"q"}, ctxList, actQuit},
+		{[]string{"/"}, ctxViewer, actFilter},
+	}
+	for _, tt := range tests {
+		m.pendingKeys = nil
+		var act keyAction
+		for _, key := range tt.keys {
+			act, m.pendingKeys = m.resolveKey(tt.ctx, key)
+		}
+		if act != tt.want {
+			t.Errorf("%v in context %d = action %d, want %d", tt.keys, tt.ctx, act, tt.want)
+		}
+	}
+	// The half-page motions have no default binding, so the viewer footer only
+	// offers them once a preset supplies one.
+	m.viewing, m.pendingKeys = true, nil
+	if footer := m.viewerFooter(); !strings.Contains(footer, "half page") {
+		t.Errorf("viewer footer = %q, want a half page chip", footer)
+	}
+	if footer := newModel(nil, false).viewerFooter(); strings.Contains(footer, "half page") {
+		t.Errorf("default viewer footer = %q, want no half page chip", footer)
+	}
+}
+
+// gg has to scroll the viewport, not just resolve: the chord path and the
+// scrolling path are separate pieces of machinery.
+func TestVimChordScrollsTheViewer(t *testing.T) {
+	km, err := PresetKeymap("vim")
+	if err != nil {
+		t.Fatalf("PresetKeymap(vim): %v", err)
+	}
+	m := newModel(nil, false)
+	m.keys, m.width, m.height = km, 80, 24
+	m.cur.name, m.cur.status = "ping the host", JobDone
+	for i := range 200 {
+		m.appendJobLine(fmt.Sprintf("line %d", i))
+	}
+	u, _ := m.handleKey(keyPress("enter"))
+	m = asModel(t, u)
+	if !m.viewing || !m.follow {
+		t.Fatalf("enter did not open the viewer at the tail (viewing=%v follow=%v)", m.viewing, m.follow)
+	}
+	view := func(m model, key string) model {
+		t.Helper()
+		u, _ := m.handleViewKey(keyPress(key))
+		return asModel(t, u)
+	}
+	m = view(m, "g")
+	if m.vp.YOffset == 0 {
+		t.Fatal("the first g scrolled on its own, before the chord finished")
+	}
+	if m = view(m, "g"); m.vp.YOffset != 0 || m.follow {
+		t.Errorf("gg left offset %d follow %v, want the top and no follow", m.vp.YOffset, m.follow)
+	}
+	if m = view(m, "ctrl+d"); m.vp.YOffset == 0 {
+		t.Error("ctrl+d did not scroll down half a page")
+	}
+	if m = view(m, "G"); m.vp.YOffset == 0 || !m.follow {
+		t.Errorf("G left offset %d follow %v, want the bottom and follow back on", m.vp.YOffset, m.follow)
 	}
 }
 

--- a/internal/ui/keymap_test.go
+++ b/internal/ui/keymap_test.go
@@ -1,6 +1,5 @@
-// The keymap's structural invariants — the ones a rebinding user relies on
-// without knowing they exist: one action per key per screen, no binding buried
-// under a chord that starts with it, and nothing shadowing a tool hotkey.
+// Structural invariants of the keymap: one action per key per screen, no
+// binding buried under a chord, nothing shadowing a tool hotkey.
 
 package ui
 
@@ -26,9 +25,8 @@ func keyPress(name string) tea.KeyMsg {
 	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(name)}
 }
 
-// Every shipped preset has to survive the same validation a user's config
-// does; a preset that couldn't be written by hand would be a keymap the
-// validator calls impossible.
+// A preset that could not be written by hand would be one the validator
+// calls impossible.
 func TestPresetsValidate(t *testing.T) {
 	for name, preset := range presets {
 		if errs := validateBindings(preset); len(errs) > 0 {
@@ -37,8 +35,7 @@ func TestPresetsValidate(t *testing.T) {
 	}
 }
 
-// The cheatsheet and the help bar both read descriptions out of actionDefs, so
-// an action missing from that table is an action nobody can discover.
+// An action missing from actionDefs is one nobody can discover.
 func TestEveryActionIsDescribed(t *testing.T) {
 	seen := map[keyAction]bool{}
 	for _, def := range actionDefs {
@@ -62,9 +59,8 @@ func TestEveryActionIsDescribed(t *testing.T) {
 	}
 }
 
-// A chord is resolved key by key, and the key that ends a dead chord still
-// gets its own turn — otherwise a stray prefix would eat the keystroke after
-// it, which reads as the app dropping input.
+// A chord resolves key by key, and the key that ends a dead one still gets its
+// own turn — otherwise a stray prefix eats the keystroke after it.
 func TestChordResolution(t *testing.T) {
 	km, errs := buildKeymap("default", map[string][]string{"top": {"g g"}})
 	if len(errs) > 0 {
@@ -98,8 +94,7 @@ func TestChordResolution(t *testing.T) {
 }
 
 // A chord in flight launches nothing, and the key that ends an unfinished one
-// behaves exactly as it would have if the prefix had never been typed — an
-// abandoned chord costs the user nothing, in either direction.
+// behaves as it would have if the prefix had never been typed.
 func TestChordHoldsTheToolboxThenReleasesIt(t *testing.T) {
 	km, errs := buildKeymap("default", map[string][]string{"help": {"z z"}})
 	if len(errs) > 0 {
@@ -115,9 +110,8 @@ func TestChordHoldsTheToolboxThenReleasesIt(t *testing.T) {
 	if m.confirmTool != nil || m.cur.name != "" {
 		t.Fatalf("z started something: confirm=%v job=%q", m.confirmTool, m.cur.name)
 	}
-	// "n" is nmap's letter. It does not complete the chord, so the chord ends
-	// and n gets the turn it would have had on its own — the confirm gate,
-	// never a launch.
+	// n is nmap's letter: it does not complete the chord, so the chord ends and n
+	// gets its own turn — the confirm gate, never a launch.
 	u, _ = m.handleKey(keyMsg("n"))
 	m = u.(model)
 	if m.pendingKeys != nil {
@@ -134,9 +128,8 @@ func TestChordHoldsTheToolboxThenReleasesIt(t *testing.T) {
 	}
 }
 
-// The vim preset's whole point is the motions, so each one is pinned against
-// the screen it moves — and against the default keys it must not have taken
-// away on its way in.
+// Each motion is pinned against the screen it moves, and against the default
+// keys the preset must not have taken away.
 func TestVimPresetMotions(t *testing.T) {
 	km, err := PresetKeymap("vim")
 	if err != nil {
@@ -189,8 +182,7 @@ func TestVimPresetMotions(t *testing.T) {
 	}
 }
 
-// gg has to scroll the viewport, not just resolve: the chord path and the
-// scrolling path are separate pieces of machinery.
+// The chord path and the scrolling path are separate machinery.
 func TestVimChordScrollsTheViewer(t *testing.T) {
 	km, err := PresetKeymap("vim")
 	if err != nil {
@@ -227,8 +219,7 @@ func TestVimChordScrollsTheViewer(t *testing.T) {
 	}
 }
 
-// The help bar and cheatsheet must show the keys that actually run, not the
-// ones the defaults used to use.
+// The help must show the keys that run, not the ones the defaults used.
 func TestHelpFollowsRebinding(t *testing.T) {
 	km, errs := buildKeymap("default", map[string][]string{"quit": {"Q"}, "restart": {"R"}})
 	if len(errs) > 0 {
@@ -251,9 +242,8 @@ func TestHelpFollowsRebinding(t *testing.T) {
 	}
 }
 
-// A rebound key can be much longer than the one it replaced, and the
-// cheatsheet's key column has to grow with it instead of running the label
-// into its description.
+// A rebound key can be longer than the one it replaced, so the cheatsheet's
+// key column has to grow rather than run the label into its description.
 func TestCheatsheetKeyColumnFitsLongLabels(t *testing.T) {
 	km, errs := buildKeymap("default", map[string][]string{"help": {"ctrl+x", "f12", "?"}})
 	if len(errs) > 0 {
@@ -275,8 +265,7 @@ func TestCheatsheetKeyColumnFitsLongLabels(t *testing.T) {
 	t.Errorf("no cheatsheet row for %q:\n%s", want, m.View())
 }
 
-// An unbound action is not advertised: a help bar offering a key that does
-// nothing is worse than a shorter help bar.
+// An unbound action is not advertised.
 func TestUnboundActionsVanishFromHelp(t *testing.T) {
 	km, errs := buildKeymap("default", map[string][]string{"network-map": {}})
 	if len(errs) > 0 {
@@ -292,8 +281,7 @@ func TestUnboundActionsVanishFromHelp(t *testing.T) {
 	}
 }
 
-// allToolKeys is hand-written, so it needs a guard that walks the real
-// toolbox: a new drill-down tool must not become bindable by accident.
+// allToolKeys is hand-written, so a guard walks the real toolbox.
 func TestAllToolKeysMatchesTheToolbox(t *testing.T) {
 	targets := []*diagnostic.Target{
 		nil,

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -180,6 +180,24 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.selMoved = true
 		return m, nil
+	case actTop:
+		if m.networkMap {
+			m.mapSelected = 0
+			return m, nil
+		}
+		m.selected = 0
+		m.selMoved = true
+		return m, nil
+	case actBottom:
+		if m.networkMap {
+			m.mapSelected = max(len(m.networkHosts())-1, 0)
+			return m, nil
+		}
+		// max, not len-1: an empty list would otherwise select row -1, and the
+		// check list is empty for as long as the first probe takes to arrive.
+		m.selected = max(len(m.probes)-1, 0)
+		m.selMoved = true
+		return m, nil
 	case actOpen:
 		if hosts := m.networkHosts(); m.networkMap && len(hosts) > 0 {
 			m.mapSelected = min(m.mapSelected, len(hosts)-1)

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -233,9 +233,45 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		notice, ok := exportReport(m.report(), act == actSave)
 		return m, m.setNotice(notice, ok)
 	case actHelp:
-		m.helping = true
+		m.helping, m.helpOffset = true, 0
 		return m, nil
 	}
+	return m, nil
+}
+
+// handleHelpKey handles keys while the cheatsheet is open. It lists every
+// binding plus the toolbox, which outgrows a short terminal, so the motions
+// that scroll output scroll the sheet as well; everything else still closes
+// it, which is the one thing users already knew about this screen.
+func (m model) handleHelpKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	act, pending := m.resolveKey(ctxViewer, msg.String())
+	m.pendingKeys = pending
+	if len(pending) > 0 {
+		return m, nil // half a chord is not "any other key"
+	}
+	page := max(m.helpVisible(), 1)
+	switch act {
+	case actUp:
+		m.helpOffset--
+	case actDown:
+		m.helpOffset++
+	case actTop:
+		m.helpOffset = 0
+	case actBottom:
+		m.helpOffset = m.helpMaxOffset()
+	case actPageUp:
+		m.helpOffset -= page
+	case actPageDown:
+		m.helpOffset += page
+	case actHalfPageUp:
+		m.helpOffset -= max(page/2, 1)
+	case actHalfPageDown:
+		m.helpOffset += max(page/2, 1)
+	default:
+		m.helping, m.helpOffset, m.pendingKeys = false, 0, nil
+		return m, nil
+	}
+	m.helpOffset = min(max(m.helpOffset, 0), m.helpMaxOffset())
 	return m, nil
 }
 
@@ -324,6 +360,11 @@ func (m model) handleViewKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case actSwitchJob:
 		return m, m.switchJob()
+	case actHelp:
+		// The viewer stays open underneath, so closing the sheet returns to
+		// the output rather than to the check list.
+		m.helping, m.helpOffset = true, 0
+		return m, nil
 	// Scrolling reads follow back off the viewport rather than setting it:
 	// any move that happens to land on the last line resumes following, and
 	// the amount a key scrolls is the viewport's business, not this switch's.

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -32,9 +32,7 @@ func (m model) resolveKey(ctx keyContext, key string) (keyAction, []string) {
 	if m.keys.isPrefix(ctx, seq) {
 		return actNone, seq
 	}
-	// The chord died on this key, but the key itself is innocent: it gets the
-	// turn it would have had on its own, so an abandoned prefix costs the
-	// keystroke after it nothing.
+	// The key that killed a chord still gets the turn it would have had alone.
 	if len(m.pendingKeys) > 0 {
 		if act, ok := m.keys.lookup(ctx, []string{key}); ok {
 			return act, nil
@@ -63,10 +61,9 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	act, pending := m.resolveKey(ctxList, msg.String())
 	m.pendingKeys = pending
 	if act == actNone {
-		// A chord still waiting for its next key owns the keyboard; letting a
-		// tool hotkey through here would launch a subprocess on the way to a
-		// movement key. A chord that just died is not waiting for anything —
-		// resolveKey has already given the key that killed it its own turn.
+		// A chord waiting for its next key owns the keyboard, or a tool hotkey would
+		// fork a subprocess on the way to a movement key. A chord that just died is
+		// not waiting: resolveKey has already given the key that killed it its turn.
 		if len(pending) > 0 {
 			return m, nil
 		}
@@ -213,9 +210,8 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.viewing, m.follow = true, true
 		m.vp = viewport.New(m.width, m.vpHeight())
-		// The viewer's own keys are dispatched by handleViewKey, which the
-		// bindings make rebindable; leaving the viewport's built-in map armed
-		// would give b/f/space/u/d a second, unconfigurable owner.
+		// handleViewKey dispatches the viewer through the bindings; leaving the
+		// viewport's built-in map armed would give b/f/space/u/d a second owner.
 		m.vp.KeyMap = viewport.KeyMap{}
 		m.refreshViewport()
 		return m, nil
@@ -239,10 +235,8 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// handleHelpKey handles keys while the cheatsheet is open. It lists every
-// binding plus the toolbox, which outgrows a short terminal, so the motions
-// that scroll output scroll the sheet as well; everything else still closes
-// it, which is the one thing users already knew about this screen.
+// handleHelpKey handles keys while the cheatsheet is open. It outgrows a short
+// terminal, so the motions that scroll output scroll it; anything else closes it.
 func (m model) handleHelpKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	act, pending := m.resolveKey(ctxViewer, msg.String())
 	m.pendingKeys = pending

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -328,17 +328,17 @@ func (m model) handleViewKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	// any move that happens to land on the last line resumes following, and
 	// the amount a key scrolls is the viewport's business, not this switch's.
 	case actUp:
-		m.vp.LineUp(1)
+		m.vp.ScrollUp(1)
 	case actDown:
-		m.vp.LineDown(1)
+		m.vp.ScrollDown(1)
 	case actPageUp:
-		m.vp.ViewUp()
+		m.vp.PageUp()
 	case actPageDown:
-		m.vp.ViewDown()
+		m.vp.PageDown()
 	case actHalfPageUp:
-		m.vp.HalfViewUp()
+		m.vp.HalfPageUp()
 	case actHalfPageDown:
-		m.vp.HalfViewDown()
+		m.vp.HalfPageDown()
 	default:
 		return m, nil
 	}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -9,10 +9,10 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -20,17 +20,74 @@ import (
 	"github.com/heymaikol/network-doctor/internal/textsafe"
 )
 
-func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "q":
-		if m.jobsRunning() {
-			m.cancelJobs() // non-blocking; quit after every terminal event
-			m.pending = &pendingAction{kind: pendQuit}
-			return m, m.setNotice("stopping jobs, then quitting", true)
+// resolveKey folds msg into whatever chord is already in flight and resolves
+// the result in ctx. It returns the action to run (actNone for none) and the
+// prefix still waiting for its next key.
+func (m model) resolveKey(ctx keyContext, key string) (keyAction, []string) {
+	key = normalizeKey(key)
+	seq := append(slices.Clone(m.pendingKeys), key)
+	if act, ok := m.keys.lookup(ctx, seq); ok {
+		return act, nil
+	}
+	if m.keys.isPrefix(ctx, seq) {
+		return actNone, seq
+	}
+	// The chord died on this key, but the key itself is innocent: it gets the
+	// turn it would have had on its own, so an abandoned prefix costs the
+	// keystroke after it nothing.
+	if len(m.pendingKeys) > 0 {
+		if act, ok := m.keys.lookup(ctx, []string{key}); ok {
+			return act, nil
 		}
-		m.clearCancel()
-		return m, tea.Quit
-	case "r":
+		if m.keys.isPrefix(ctx, []string{key}) {
+			return actNone, []string{key}
+		}
+	}
+	return actNone, nil
+}
+
+// quit is the stop-everything path, reached by its binding and by the second
+// Ctrl+C. Running jobs are cancelled first and the quit deferred until their
+// terminal events land.
+func (m model) quit() (tea.Model, tea.Cmd) {
+	if m.jobsRunning() {
+		m.cancelJobs() // non-blocking; quit after every terminal event
+		m.pending = &pendingAction{kind: pendQuit}
+		return m, m.setNotice("stopping jobs, then quitting", true)
+	}
+	m.clearCancel()
+	return m, tea.Quit
+}
+
+func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	act, pending := m.resolveKey(ctxList, msg.String())
+	m.pendingKeys = pending
+	if act == actNone {
+		// A chord still waiting for its next key owns the keyboard; letting a
+		// tool hotkey through here would launch a subprocess on the way to a
+		// movement key. A chord that just died is not waiting for anything —
+		// resolveKey has already given the key that killed it its own turn.
+		if len(pending) > 0 {
+			return m, nil
+		}
+		// Tool hotkeys (contextual toolbox). Bindings are validated against
+		// these letters, so this is reached only for keys no action claims.
+		for _, tool := range m.tools {
+			if msg.String() == tool.Key {
+				if tool.Confirm {
+					t := tool // hold for the confirm gate; run happens on 'y'
+					m.confirmTool = &t
+					return m, nil
+				}
+				return m, m.launchTool(tool)
+			}
+		}
+		return m, nil
+	}
+	switch act {
+	case actQuit:
+		return m.quit()
+	case actRestart:
 		// Open the restart prompt; an active job keeps streaming until Enter commits.
 		m.entering, m.sshPrompt, m.inputErr = true, false, ""
 		ti := textinput.New()
@@ -45,7 +102,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		ti.CursorEnd()
 		m.input = ti
 		return m, textinput.Blink
-	case "S":
+	case actSSH:
 		// The SSH login form is offered for every target, unlike the 'c'
 		// handshake check, which only fits an SSH one. It logs in to the
 		// machine under test, so it needs a target and takes the host from it.
@@ -57,7 +114,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.sshPrompt, m.ssh = true, newSSHForm(m.target)
 		return m, textinput.Blink
-	case "v":
+	case actNetworkMap:
 		if m.networkMap {
 			m.networkMap = false
 			return m, nil
@@ -89,17 +146,17 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Same confirm gate as nmap: a /24 sweep is an active scan too.
 		m.confirmTool = &tool
 		return m, nil
-	case "esc":
-		// Cancel only the focused job (tab picks which); q remains the
+	case actCancelJob:
+		// Cancel only the focused job (tab picks which); quit remains the
 		// nuke-everything path. The terminal event arrives as JobCanceled.
 		if m.cur.active != nil && m.cur.active.cancel != nil {
 			m.cur.active.cancel()
 			return m, m.setNotice("canceling "+m.cur.name, true)
 		}
 		return m, nil
-	case "tab":
+	case actSwitchJob:
 		return m, m.switchJob()
-	case "up", "k":
+	case actUp:
 		if m.networkMap {
 			if m.mapSelected > 0 {
 				m.mapSelected--
@@ -111,7 +168,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.selMoved = true
 		return m, nil
-	case "down", "j":
+	case actDown:
 		if m.networkMap {
 			if m.mapSelected < len(m.networkHosts())-1 {
 				m.mapSelected++
@@ -123,7 +180,7 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.selMoved = true
 		return m, nil
-	case "enter":
+	case actOpen:
 		if hosts := m.networkHosts(); m.networkMap && len(hosts) > 0 {
 			m.mapSelected = min(m.mapSelected, len(hosts)-1)
 			address, _, _ := strings.Cut(hosts[m.mapSelected], " ")
@@ -138,17 +195,14 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.viewing, m.follow = true, true
 		m.vp = viewport.New(m.width, m.vpHeight())
-		// Zero-value bindings disable everything else (b/f/space, u/d).
-		m.vp.KeyMap = viewport.KeyMap{
-			Up:       key.NewBinding(key.WithKeys("up", "k")),
-			Down:     key.NewBinding(key.WithKeys("down", "j")),
-			PageUp:   key.NewBinding(key.WithKeys("pgup")),
-			PageDown: key.NewBinding(key.WithKeys("pgdown")),
-		}
+		// The viewer's own keys are dispatched by handleViewKey, which the
+		// bindings make rebindable; leaving the viewport's built-in map armed
+		// would give b/f/space/u/d a second, unconfigurable owner.
+		m.vp.KeyMap = viewport.KeyMap{}
 		m.refreshViewport()
 		return m, nil
-	case "y", "w":
-		if portalURL := m.selectedPortalURL(); portalURL != "" && msg.String() == "y" {
+	case actCopy, actSave:
+		if portalURL := m.selectedPortalURL(); portalURL != "" && act == actCopy {
 			notice, ok := "portal URL sent to clipboard (OSC 52)", true
 			if err := copyReport(portalURL); err != nil {
 				notice, ok = "copy failed: "+err.Error(), false
@@ -158,22 +212,11 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if !m.reportReady() {
 			return m, m.setNotice("report not ready until checks finish", false)
 		}
-		notice, ok := exportReport(m.report(), msg.String() == "w")
+		notice, ok := exportReport(m.report(), act == actSave)
 		return m, m.setNotice(notice, ok)
-	case "?":
+	case actHelp:
 		m.helping = true
 		return m, nil
-	}
-	// Tool hotkeys (contextual toolbox).
-	for _, tool := range m.tools {
-		if msg.String() == tool.Key {
-			if tool.Confirm {
-				t := tool // hold for the confirm gate; run happens on 'y'
-				m.confirmTool = &t
-				return m, nil
-			}
-			return m, m.launchTool(tool)
-		}
 	}
 	return m, nil
 }
@@ -213,18 +256,23 @@ func (m model) handleViewKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.refreshViewport()
 		return m, cmd
 	}
-	switch msg.String() {
-	case "esc", "q":
-		if msg.String() == "esc" && m.filter != "" {
-			// First esc clears the committed filter, second one leaves.
+	act, pending := m.resolveKey(ctxViewer, msg.String())
+	m.pendingKeys = pending
+	switch act {
+	case actClearFilter:
+		if m.filter != "" {
+			// A filter is cleared before the viewer is left, so the key that
+			// removes it doesn't also throw away the output it was hiding.
 			m.filter = ""
 			m.refreshViewport()
 			return m, nil
 		}
+		fallthrough
+	case actBack:
 		m.viewing = false
 		m.filter = "" // a stale filter reopening as a blank screen reads as lost output
 		return m, nil
-	case "/":
+	case actFilter:
 		m.filtering = true
 		ti := textinput.New()
 		ti.Prompt = "/"
@@ -235,31 +283,49 @@ func (m model) handleViewKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.filterInput = ti
 		m.refreshViewport()
 		return m, textinput.Blink
-	case "y":
-		notice, ok := "output sent to clipboard (OSC 52) — w saves a file", true
+	case actCopy:
+		notice, ok := "output sent to clipboard (OSC 52)", true
+		if m.keys.bound(actSave) {
+			notice += " — " + m.keys.label(actSave) + " saves a file"
+		}
 		if err := copyReport(strings.Join(m.visibleJobLines(), "\n")); err != nil {
 			notice, ok = "copy failed: "+err.Error(), false
 		}
 		return m, m.setNotice(notice, ok)
-	case "w":
+	case actSave:
 		notice, ok := exportReport(strings.Join(m.visibleJobLines(), "\n"), true)
 		notice = strings.Replace(notice, "report saved", "output saved", 1)
 		return m, m.setNotice(notice, ok)
-	case "home":
+	case actTop:
 		m.vp.GotoTop()
 		m.follow = false
 		return m, nil
-	case "end":
+	case actBottom:
 		m.vp.GotoBottom()
 		m.follow = true
 		return m, nil
-	case "tab":
+	case actSwitchJob:
 		return m, m.switchJob()
+	// Scrolling reads follow back off the viewport rather than setting it:
+	// any move that happens to land on the last line resumes following, and
+	// the amount a key scrolls is the viewport's business, not this switch's.
+	case actUp:
+		m.vp.LineUp(1)
+	case actDown:
+		m.vp.LineDown(1)
+	case actPageUp:
+		m.vp.ViewUp()
+	case actPageDown:
+		m.vp.ViewDown()
+	case actHalfPageUp:
+		m.vp.HalfViewUp()
+	case actHalfPageDown:
+		m.vp.HalfViewDown()
+	default:
+		return m, nil
 	}
-	var cmd tea.Cmd
-	m.vp, cmd = m.vp.Update(msg)
 	m.follow = m.vp.AtBottom()
-	return m, cmd
+	return m, nil
 }
 
 // handlePromptKey handles keys while the restart prompt is open. Enter parses

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -106,8 +106,11 @@ const (
 	maxParkedJobs = 12
 	ctrlCWindow   = 2 * time.Second
 	noticeWindow  = 4 * time.Second
-	watchRuns     = 20
-	ctrlCNotice   = "Press Ctrl+C again to quit"
+	// startupNoticeWindow holds a pre-TUI complaint long enough to be read by
+	// someone who was looking at the banner, not waiting for a reply.
+	startupNoticeWindow = 12 * time.Second
+	watchRuns           = 20
+	ctrlCNotice         = "Press Ctrl+C again to quit"
 )
 
 // WatchEvery is the gap between repeat passes in watch mode, shared so the TUI
@@ -251,6 +254,17 @@ func WithKeymap(km Keymap) Option {
 	return func(m *model) { m.keys = km }
 }
 
+// WithStartupNotice opens the run with one line of feedback, for something
+// that went wrong before the TUI existed — a rejected config file being the
+// only current caller. It holds longer than an ordinary notice: nothing the
+// user did triggered it, so nothing tells them to be looking when it appears.
+func WithStartupNotice(msg string) Option {
+	return func(m *model) {
+		m.notice, m.noticeOK = textsafe.Clean(msg), false
+		m.noticeDeadline = time.Now().Add(startupNoticeWindow)
+	}
+}
+
 // NewWithSelection applies a validated CLI probe policy to this run and every
 // target switch made from it.
 func NewWithSelection(t *diagnostic.Target, sources *diagnostic.SourceAddresses, toolbox, watch bool, histFile, version, publicDNS string, selection diagnostic.ProbeSelection, opts ...Option) tea.Model {
@@ -353,10 +367,20 @@ func saveHistory(path string, hist []string) {
 }
 
 func (m model) Init() tea.Cmd {
-	if m.toolbox {
-		return m.spinner.Tick // chain deferred until 'r'; tick drives the job timer
+	cmds := []tea.Cmd{m.spinner.Tick} // chain deferred until 'r' in toolbox mode; tick drives the job timer
+	if !m.toolbox {
+		cmds = append(cmds, func() tea.Msg { return scheduleMsg{gen: 0} })
 	}
-	return tea.Batch(m.spinner.Tick, func() tea.Msg { return scheduleMsg{gen: 0} })
+	// A notice set before the program started has its deadline but not yet the
+	// tick that clears it; setNotice can't run here, since Init's mutations
+	// are discarded.
+	if !m.noticeDeadline.IsZero() {
+		deadline := m.noticeDeadline
+		cmds = append(cmds, tea.Tick(time.Until(deadline), func(time.Time) tea.Msg {
+			return noticeDoneMsg{deadline: deadline}
+		}))
+	}
+	return tea.Batch(cmds...)
 }
 
 // chainRan reports whether the diagnostic chain has been started this session.

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -195,7 +195,14 @@ type model struct {
 	// showing the exact command until 'y' runs it or esc cancels.
 	confirmTool *Tool
 
-	helping bool // ?: full-screen key cheatsheet; any key closes it
+	helping bool // full-screen key cheatsheet; any key closes it
+
+	// keys resolves keypresses to actions. The zero value is the default
+	// keymap, so a model built without one behaves as netdoc always has.
+	// pendingKeys is the unfinished start of a chord ("g" of "gg") waiting
+	// for the key that completes it.
+	keys        Keymap
+	pendingKeys []string
 
 	toolbox    bool // --toolbox: chain deferred until 'r'
 	watch      bool
@@ -412,8 +419,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.handleConfirmKey(msg)
 		}
 		if msg.Type == tea.KeyCtrlC {
+			// Ctrl+C reaches quit directly rather than through the quit
+			// binding: it is the terminal's own way out, and rebinding quit
+			// must not take it away.
 			if m.notice == ctrlCNotice && time.Now().Before(m.noticeDeadline) {
-				return m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+				return m.quit()
 			}
 			return m, m.setNotice(ctrlCNotice, false)
 		}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -198,7 +198,11 @@ type model struct {
 	// showing the exact command until 'y' runs it or esc cancels.
 	confirmTool *Tool
 
-	helping bool // full-screen key cheatsheet; any key closes it
+	// Full-screen key cheatsheet. It outgrows a short terminal, so it scrolls:
+	// helpOffset is the first row on screen, and any key that isn't a motion
+	// still closes the whole thing.
+	helping    bool
+	helpOffset int
 
 	// keys resolves keypresses to actions. The zero value is the default
 	// keymap, so a model built without one behaves as netdoc always has.
@@ -447,9 +451,23 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		// Runes read from stdin in one batch arrive as a single KeyMsg
+		// ("jjj"), which matches no binding; replay them one key at a time.
+		// This comes first so that no screen below ever sees a batch: a chord
+		// typed fast is the same two keys as a chord typed slowly, and a
+		// screen that closes on "any key" must not close on a whole handful.
+		if msg.Type == tea.KeyRunes && !msg.Paste && len(msg.Runes) > 1 {
+			var cmds []tea.Cmd
+			cur := tea.Model(m)
+			for _, r := range msg.Runes {
+				var cmd tea.Cmd
+				cur, cmd = cur.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+				cmds = append(cmds, cmd)
+			}
+			return cur, tea.Batch(cmds...)
+		}
 		if m.helping {
-			m.helping = false
-			return m, nil
+			return m.handleHelpKey(msg)
 		}
 		// Ctrl+C while the confirm gate is up cancels the gate, not the app.
 		if msg.Type == tea.KeyCtrlC && m.confirmTool != nil {
@@ -463,18 +481,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m.quit()
 			}
 			return m, m.setNotice(ctrlCNotice, false)
-		}
-		// Runes read from stdin in one batch arrive as a single KeyMsg
-		// ("jjj"), which matches no binding; replay them one key at a time.
-		if msg.Type == tea.KeyRunes && !msg.Paste && len(msg.Runes) > 1 {
-			var cmds []tea.Cmd
-			cur := tea.Model(m)
-			for _, r := range msg.Runes {
-				var cmd tea.Cmd
-				cur, cmd = cur.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
-				cmds = append(cmds, cmd)
-			}
-			return cur, tea.Batch(cmds...)
 		}
 		if m.confirmTool != nil {
 			return m.handleConfirmKey(msg)

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -241,9 +241,19 @@ var (
 	}
 )
 
+// Option adjusts a new model. Everything the TUI needs to run is a positional
+// argument; options are for what the user configured rather than what the run
+// requires, so leaving them all off yields netdoc's stock behavior.
+type Option func(*model)
+
+// WithKeymap runs the TUI on a resolved keymap instead of the default one.
+func WithKeymap(km Keymap) Option {
+	return func(m *model) { m.keys = km }
+}
+
 // NewWithSelection applies a validated CLI probe policy to this run and every
 // target switch made from it.
-func NewWithSelection(t *diagnostic.Target, sources *diagnostic.SourceAddresses, toolbox, watch bool, histFile, version, publicDNS string, selection diagnostic.ProbeSelection) tea.Model {
+func NewWithSelection(t *diagnostic.Target, sources *diagnostic.SourceAddresses, toolbox, watch bool, histFile, version, publicDNS string, selection diagnostic.ProbeSelection, opts ...Option) tea.Model {
 	allProbes := diagnostic.BuildProbesFromSources(t, sources, publicDNS)
 	probes := selection.Apply(allProbes)
 	sp := spinner.New()
@@ -266,6 +276,9 @@ func NewWithSelection(t *diagnostic.Target, sources *diagnostic.SourceAddresses,
 		histPath:         histFile,
 		version:          version,
 		width:            100, // placeholder until the terminal introduces itself (WindowSizeMsg)
+	}
+	for _, opt := range opts {
+		opt(&m)
 	}
 	m.history = loadHistory(histFile)
 	if t != nil {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -248,9 +248,8 @@ var (
 	}
 )
 
-// Option adjusts a new model. Everything the TUI needs to run is a positional
-// argument; options are for what the user configured rather than what the run
-// requires, so leaving them all off yields netdoc's stock behavior.
+// Option adjusts a new model. Everything the TUI needs to run is positional;
+// options are for what the user configured.
 type Option func(*model)
 
 // WithKeymap runs the TUI on a resolved keymap instead of the default one.
@@ -258,10 +257,9 @@ func WithKeymap(km Keymap) Option {
 	return func(m *model) { m.keys = km }
 }
 
-// WithStartupNotice opens the run with one line of feedback, for something
-// that went wrong before the TUI existed — a rejected config file being the
-// only current caller. It holds longer than an ordinary notice: nothing the
-// user did triggered it, so nothing tells them to be looking when it appears.
+// WithStartupNotice opens the run with one line of feedback about something
+// that went wrong before the TUI existed. It holds longer than an ordinary
+// notice, since nothing the user did triggered it.
 func WithStartupNotice(msg string) Option {
 	return func(m *model) {
 		m.notice, m.noticeOK = textsafe.Clean(msg), false
@@ -451,11 +449,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
-		// Runes read from stdin in one batch arrive as a single KeyMsg
-		// ("jjj"), which matches no binding; replay them one key at a time.
-		// This comes first so that no screen below ever sees a batch: a chord
-		// typed fast is the same two keys as a chord typed slowly, and a
-		// screen that closes on "any key" must not close on a whole handful.
+		// Runes read from stdin in one batch arrive as a single KeyMsg ("jjj"), which
+		// matches no binding; replay them one at a time. First, so no screen below sees
+		// a batch: a chord typed fast must be the same two keys as one typed slowly.
 		if msg.Type == tea.KeyRunes && !msg.Paste && len(msg.Runes) > 1 {
 			var cmds []tea.Cmd
 			cur := tea.Model(m)

--- a/internal/ui/tools.go
+++ b/internal/ui/tools.go
@@ -131,6 +131,19 @@ func cacheAvailability(tools []Tool) []Tool {
 	return tools
 }
 
+// allToolKeys is every letter the contextual toolbox can claim, across every
+// target shape and GOOS. Key bindings are validated against it rather than
+// against the toolbox of the moment: a binding on one of these letters would
+// shadow a tool that only some targets offer, so the clash would surface as a
+// tool that mysteriously stopped working on one target instead of as a config
+// error at startup. TestAllToolKeysMatchesTheToolbox walks toolsFor to keep
+// the list honest.
+//
+// lanDiscoveryTool's "v" is deliberately absent: that tool is reached through
+// the network-map action, never by its own key, so the letter is the action's
+// to bind or move.
+func allToolKeys() []string { return []string{"c", "d", "i", "m", "n", "p", "s", "t"} }
+
 // toolsFor returns the drill-down tools for the target on the given GOOS
 // (production passes runtime.GOOS; tests exercise all tables from one OS).
 // Same hotkeys everywhere. The target-independent tools (routes, sockets) are

--- a/internal/ui/tools.go
+++ b/internal/ui/tools.go
@@ -132,16 +132,11 @@ func cacheAvailability(tools []Tool) []Tool {
 }
 
 // allToolKeys is every letter the contextual toolbox can claim, across every
-// target shape and GOOS. Key bindings are validated against it rather than
-// against the toolbox of the moment: a binding on one of these letters would
-// shadow a tool that only some targets offer, so the clash would surface as a
-// tool that mysteriously stopped working on one target instead of as a config
-// error at startup. TestAllToolKeysMatchesTheToolbox walks toolsFor to keep
-// the list honest.
-//
-// lanDiscoveryTool's "v" is deliberately absent: that tool is reached through
-// the network-map action, never by its own key, so the letter is the action's
-// to bind or move.
+// target shape and GOOS. Key bindings are validated against the whole set, not
+// the toolbox of the moment, so shadowing a tool is a startup error rather than
+// a tool that stops working on some targets. TestAllToolKeysMatchesTheToolbox
+// keeps the list honest. lanDiscoveryTool's "v" is absent because that tool is
+// reached through the network-map action, never by its own key.
 func allToolKeys() []string { return []string{"c", "d", "i", "m", "n", "p", "s", "t"} }
 
 // toolsFor returns the drill-down tools for the target on the given GOOS

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -624,9 +624,19 @@ func (m model) chordHint(help string) string {
 // exception is S: the form works against any target, but advertising a login
 // to a host with no SSH server on it is a suggestion, not information.
 func (m model) helpOverlay() string {
+	// The key column is sized to what is actually bound, not to a constant:
+	// rebinding can make a label as long as "ctrl+b/pgup", which a fixed width
+	// would run straight into its description.
+	keyWidth := 8
+	for _, def := range actionDefs {
+		if m.keys.bound(def.act) {
+			keyWidth = max(keyWidth, lipgloss.Width(m.keys.label(def.act)))
+		}
+	}
 	row := func(k, desc string) string {
-		// fmt widths count runes, so ↑/↓ pads the same as ASCII keys.
-		return "  " + keyStyle.Render(fmt.Sprintf("%-10s", k)) + faintStyle.Render(desc) + "\n"
+		return "  " + keyStyle.Render(k) +
+			strings.Repeat(" ", max(keyWidth-lipgloss.Width(k), 0)+2) +
+			faintStyle.Render(desc) + "\n"
 	}
 	// Both sections are generated from the same table the keys dispatch
 	// through, so a rebound key is documented by the act of rebinding it and

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -540,56 +540,82 @@ func (m model) helpView(deferred bool) string {
 	if m.networkMap {
 		hosts = len(m.networkHosts())
 	}
+	// Every chip is looked up in the keymap and dropped when the action has no
+	// key: a user who unbinds something should stop being advertised it, not
+	// be pointed at a key that does nothing.
 	var kv []string
+	add := func(label, desc string) {
+		if label != "" {
+			kv = append(kv, label, desc)
+		}
+	}
+	move := m.keys.pairLabel(actUp, actDown)
 	switch {
 	case m.networkMap:
 		if hosts > 0 {
-			kv = []string{"↑/↓", "select device", "enter", "set target"}
+			add(move, "select device")
+			add(m.keys.label(actOpen), "set target")
 		}
-		kv = append(kv, "v", "checks")
+		add(m.keys.label(actNetworkMap), "checks")
 	case deferred:
-		kv = []string{"r", "run the checks", "v", "network map"}
+		add(m.keys.label(actRestart), "run the checks")
+		add(m.keys.label(actNetworkMap), "network map")
 		if len(m.tools) > 0 {
 			kv = append(kv, "letter", "runs that tool")
 		}
 	default:
-		kv = []string{"↑/↓", "scroll", "v", "network map"}
+		add(move, "scroll")
+		add(m.keys.label(actNetworkMap), "network map")
 	}
-	// Enter opens the output viewer whenever a job pane exists (same condition
-	// as jobView), so the hint tracks exactly when the key does something — on
-	// the map with devices listed, enter sets the target instead.
+	// Open works whenever a job pane exists (same condition as jobView), so the
+	// hint tracks exactly when the key does something — on the map with devices
+	// listed, it sets the target instead.
 	if m.hasJob() && (!m.networkMap || hosts == 0) {
-		kv = append(kv, "enter", "full output")
+		add(m.keys.label(actOpen), "full output")
 	}
 	if !deferred && m.cur.active != nil {
-		kv = append(kv, "esc", "cancel job")
+		add(m.keys.label(actCancelJob), "cancel job")
 	}
 	if len(m.otherJobs) > 0 {
-		kv = append(kv, "tab", "switch job")
+		add(m.keys.label(actSwitchJob), "switch job")
 	}
 	if deferred {
 		if m.networkMap {
-			kv = append(kv, "r", "run the checks")
+			add(m.keys.label(actRestart), "run the checks")
 		}
-		return helpKeys(m.width, append(kv, "?", "help", "q", "quit")...)
+		add(m.keys.label(actHelp), "help")
+		add(m.keys.label(actQuit), "quit")
+		return m.chordHint(helpKeys(m.width, kv...))
 	}
 	if m.selectedPortalURL() != "" {
-		kv = append(kv, "y", "copy portal URL")
+		add(m.keys.label(actCopy), "copy portal URL")
 	} else if m.reportReady() {
-		kv = append(kv, "y", "copy report")
+		add(m.keys.label(actCopy), "copy report")
 	}
 	if m.reportReady() {
-		kv = append(kv, "w", "save report")
+		add(m.keys.label(actSave), "save report")
 	}
 	if m.sshDetected() {
-		kv = append(kv, "S", "ssh login")
+		add(m.keys.label(actSSH), "ssh login")
 	}
-	kv = append(kv, "r", "restart", "?", "help", "q", "quit")
-	help := helpKeys(m.width, kv...)
+	add(m.keys.label(actRestart), "restart")
+	add(m.keys.label(actHelp), "help")
+	add(m.keys.label(actQuit), "quit")
+	help := m.chordHint(helpKeys(m.width, kv...))
 	if notice := m.noticeView(); notice != "" {
 		help = notice + "\n" + help
 	}
 	return help
+}
+
+// chordHint prefixes the help bar with the half-typed chord, the way vim's
+// showcmd does. Without it the first key of a chord looks like a keypress the
+// app dropped.
+func (m model) chordHint(help string) string {
+	if len(m.pendingKeys) == 0 {
+		return help
+	}
+	return keyStyle.Render(displaySeq(strings.Join(m.pendingKeys, " "))+"…") + faintStyle.Render("  ·  ") + help
 }
 
 // helpOverlay is the full-screen key cheatsheet (?). It lists every binding
@@ -602,31 +628,29 @@ func (m model) helpOverlay() string {
 		// fmt widths count runes, so ↑/↓ pads the same as ASCII keys.
 		return "  " + keyStyle.Render(fmt.Sprintf("%-10s", k)) + faintStyle.Render(desc) + "\n"
 	}
+	// Both sections are generated from the same table the keys dispatch
+	// through, so a rebound key is documented by the act of rebinding it and
+	// an unbound action stops being listed.
+	section := func(b *strings.Builder, ctx keyContext) {
+		for _, def := range actionDefs {
+			desc, ok := def.desc[ctx]
+			if !ok || !m.keys.bound(def.act) {
+				continue
+			}
+			if def.act == actSSH && !m.sshDetected() {
+				continue
+			}
+			b.WriteString(row(m.keys.label(def.act), desc))
+		}
+	}
 	var b strings.Builder
 	b.WriteString(panelTitleStyle.Render("Keys") + "\n")
-	b.WriteString(row("↑/↓ j/k", "select check — or device on the network map"))
-	b.WriteString(row("enter", "full output — or set target on the network map"))
-	b.WriteString(row("tab", "switch job"))
-	b.WriteString(row("esc", "cancel the focused job"))
-	b.WriteString(row("v", "toggle network map"))
-	b.WriteString(row("r", "restart with a new target"))
-	if m.sshDetected() {
-		b.WriteString(row("S", "ssh to a host — hands the terminal to ssh"))
-	}
-	b.WriteString(row("y", "copy selected portal URL, otherwise report"))
-	b.WriteString(row("w", "save report"))
+	section(&b, ctxList)
 	for _, tool := range m.tools {
 		b.WriteString(row(tool.Key, "run "+tool.Name))
 	}
-	b.WriteString(row("q", "quit"))
 	b.WriteString("\n" + panelTitleStyle.Render("Output viewer") + "\n")
-	b.WriteString(row("↑/↓", "scroll"))
-	b.WriteString(row("pgup/pgdn", "page"))
-	b.WriteString(row("home/end", "jump to top / bottom"))
-	b.WriteString(row("/", "filter lines"))
-	b.WriteString(row("y", "copy output (filtered if a filter is on)"))
-	b.WriteString(row("w", "save output (filtered if a filter is on)"))
-	b.WriteString(row("esc/q", "back"))
+	section(&b, ctxViewer)
 	out := b.String() + "\n" + helpKeys(m.width, "any key", "close")
 	if m.height > 0 {
 		out = lipgloss.NewStyle().MaxHeight(m.height).Render(out)
@@ -770,14 +794,31 @@ func (m model) viewerFooter() string {
 	if notice := m.noticeView(); notice != "" {
 		return notice
 	}
-	kv := []string{"↑/↓", "scroll", "pgup/pgdn", "page", "home/end", "top/bottom", "/", "filter"}
+	var kv []string
+	add := func(label, desc string) {
+		if label != "" {
+			kv = append(kv, label, desc)
+		}
+	}
+	add(m.keys.pairLabel(actUp, actDown), "scroll")
+	add(m.keys.pairLabel(actPageUp, actPageDown), "page")
+	add(m.keys.pairLabel(actHalfPageUp, actHalfPageDown), "half page")
+	add(m.keys.pairLabel(actTop, actBottom), "top/bottom")
+	add(m.keys.label(actFilter), "filter")
 	if len(m.otherJobs) > 0 {
-		kv = append(kv, "tab", "switch job")
+		add(m.keys.label(actSwitchJob), "switch job")
 	}
+	add(m.keys.label(actCopy), "copy output")
+	add(m.keys.label(actSave), "save output")
+	// With a filter applied the two exits do different things, so they stop
+	// sharing a chip and say which is which.
 	if m.filter != "" {
-		return helpKeys(m.width, append(kv, "y", "copy output", "w", "save output", "esc", "clear filter", "q", "back")...)
+		add(m.keys.label(actClearFilter), "clear filter")
+		add(m.keys.label(actBack), "back")
+		return m.chordHint(helpKeys(m.width, kv...))
 	}
-	return helpKeys(m.width, append(kv, "y", "copy output", "w", "save output", "esc/q", "back")...)
+	add(m.keys.pairLabel(actClearFilter, actBack), "back")
+	return m.chordHint(helpKeys(m.width, kv...))
 }
 
 // vpContext is the viewport position line, in wrapped display-line numbers:

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -624,12 +624,12 @@ func (m model) chordHint(help string) string {
 	return keyStyle.Render(displaySeq(strings.Join(m.pendingKeys, " "))+"…") + faintStyle.Render("  ·  ") + help
 }
 
-// helpOverlay is the full-screen key cheatsheet (?). It lists every binding
-// unconditionally — simpler than mirroring the help bar's context rules, and
-// a key that currently does nothing is still worth knowing about. The lone
-// exception is S: the form works against any target, but advertising a login
-// to a host with no SSH server on it is a suggestion, not information.
-func (m model) helpOverlay() string {
+// helpBody is the cheatsheet's rows: every binding, unconditionally — simpler
+// than mirroring the help bar's context rules, and a key that currently does
+// nothing is still worth knowing about. The lone exception is S: the form
+// works against any target, but advertising a login to a host with no SSH
+// server on it is a suggestion, not information.
+func (m model) helpBody() []string {
 	// The key column is sized to what is actually bound, not to a constant:
 	// rebinding can make a label as long as "ctrl+b/pgup", which a fixed width
 	// would run straight into its description.
@@ -667,7 +667,48 @@ func (m model) helpOverlay() string {
 	}
 	b.WriteString("\n" + panelTitleStyle.Render("Output viewer") + "\n")
 	section(&b, ctxViewer)
-	out := b.String() + "\n" + helpKeys(m.width, "any key", "close")
+	return strings.Split(strings.TrimRight(b.String(), "\n"), "\n")
+}
+
+// helpVisible is how many cheatsheet rows fit on screen, reserving the last
+// two for the blank line and the footer. Before the terminal has introduced
+// itself nothing is clipped, so everything is visible.
+func (m model) helpVisible() int {
+	if m.height <= 0 {
+		return len(m.helpBody())
+	}
+	return max(m.height-2, 1)
+}
+
+// helpMaxOffset is the furthest the sheet can scroll: the last screenful,
+// never past it.
+func (m model) helpMaxOffset() int { return max(len(m.helpBody())-m.helpVisible(), 0) }
+
+// helpOverlay is the full-screen key cheatsheet (?). It is taller than a short
+// terminal — the whole point of it is to be exhaustive — so it scrolls rather
+// than being silently cut off at whatever row the terminal ends on, which is
+// what it used to do to its own second half.
+func (m model) helpOverlay() string {
+	lines := m.helpBody()
+	visible, total := m.helpVisible(), len(lines)
+	footer := helpKeys(m.width, "any key", "close")
+	if total > visible {
+		off := min(max(m.helpOffset, 0), total-visible)
+		lines = lines[off : off+visible]
+		var kv []string
+		if scroll := m.keys.pairLabel(actUp, actDown); scroll != "" {
+			kv = append(kv, scroll, "scroll")
+		}
+		if ends := m.keys.pairLabel(actTop, actBottom); ends != "" {
+			kv = append(kv, ends, "top/bottom")
+		}
+		// "any other key", not "any key": the motions above are the exception
+		// this screen did not used to have.
+		kv = append(kv, "any other key", "close")
+		footer = faintStyle.Render(fmt.Sprintf("%d–%d of %d  ·  ", off+1, off+visible, total)) +
+			helpKeys(m.width, kv...)
+	}
+	out := strings.Join(lines, "\n") + "\n\n" + m.chordHint(footer)
 	if m.height > 0 {
 		out = lipgloss.NewStyle().MaxHeight(m.height).Render(out)
 	}
@@ -826,6 +867,7 @@ func (m model) viewerFooter() string {
 	}
 	add(m.keys.label(actCopy), "copy output")
 	add(m.keys.label(actSave), "save output")
+	add(m.keys.label(actHelp), "help")
 	// With a filter applied the two exits do different things, so they stop
 	// sharing a chip and say which is which.
 	if m.filter != "" {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -579,13 +579,23 @@ func (m model) helpView(deferred bool) string {
 	if len(m.otherJobs) > 0 {
 		add(m.keys.label(actSwitchJob), "switch job")
 	}
+	// withNotice is applied to every exit, including the deferred one: a
+	// notice raised before the chain has run — a tool that would not launch,
+	// or a config netdoc could not use — is exactly the kind that has nothing
+	// else on screen to explain it.
+	withNotice := func(help string) string {
+		if notice := m.noticeView(); notice != "" {
+			return notice + "\n" + help
+		}
+		return help
+	}
 	if deferred {
 		if m.networkMap {
 			add(m.keys.label(actRestart), "run the checks")
 		}
 		add(m.keys.label(actHelp), "help")
 		add(m.keys.label(actQuit), "quit")
-		return m.chordHint(helpKeys(m.width, kv...))
+		return withNotice(m.chordHint(helpKeys(m.width, kv...)))
 	}
 	if m.selectedPortalURL() != "" {
 		add(m.keys.label(actCopy), "copy portal URL")
@@ -601,11 +611,7 @@ func (m model) helpView(deferred bool) string {
 	add(m.keys.label(actRestart), "restart")
 	add(m.keys.label(actHelp), "help")
 	add(m.keys.label(actQuit), "quit")
-	help := m.chordHint(helpKeys(m.width, kv...))
-	if notice := m.noticeView(); notice != "" {
-		help = notice + "\n" + help
-	}
-	return help
+	return withNotice(m.chordHint(helpKeys(m.width, kv...)))
 }
 
 // chordHint prefixes the help bar with the half-typed chord, the way vim's

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -579,10 +579,8 @@ func (m model) helpView(deferred bool) string {
 	if len(m.otherJobs) > 0 {
 		add(m.keys.label(actSwitchJob), "switch job")
 	}
-	// withNotice is applied to every exit, including the deferred one: a
-	// notice raised before the chain has run — a tool that would not launch,
-	// or a config netdoc could not use — is exactly the kind that has nothing
-	// else on screen to explain it.
+	// Applied to every exit, including the deferred one: a notice raised before
+	// the chain has run has nothing else on screen to explain it.
 	withNotice := func(help string) string {
 		if notice := m.noticeView(); notice != "" {
 			return notice + "\n" + help
@@ -614,9 +612,8 @@ func (m model) helpView(deferred bool) string {
 	return withNotice(m.chordHint(helpKeys(m.width, kv...)))
 }
 
-// chordHint prefixes the help bar with the half-typed chord, the way vim's
-// showcmd does. Without it the first key of a chord looks like a keypress the
-// app dropped.
+// chordHint prefixes the help bar with a half-typed chord, as vim's showcmd
+// does, so the first key of one does not look like a dropped keypress.
 func (m model) chordHint(help string) string {
 	if len(m.pendingKeys) == 0 {
 		return help
@@ -624,15 +621,11 @@ func (m model) chordHint(help string) string {
 	return keyStyle.Render(displaySeq(strings.Join(m.pendingKeys, " "))+"…") + faintStyle.Render("  ·  ") + help
 }
 
-// helpBody is the cheatsheet's rows: every binding, unconditionally — simpler
-// than mirroring the help bar's context rules, and a key that currently does
-// nothing is still worth knowing about. The lone exception is S: the form
-// works against any target, but advertising a login to a host with no SSH
-// server on it is a suggestion, not information.
+// helpBody is the cheatsheet's rows: every binding, unconditionally. The lone
+// exception is S, which advertises a login only once one is known to be there.
 func (m model) helpBody() []string {
-	// The key column is sized to what is actually bound, not to a constant:
-	// rebinding can make a label as long as "ctrl+b/pgup", which a fixed width
-	// would run straight into its description.
+	// The key column is sized to what is bound: rebinding can make a label as long
+	// as "ctrl+b/pgup", which a fixed width would run into its description.
 	keyWidth := 8
 	for _, def := range actionDefs {
 		if m.keys.bound(def.act) {
@@ -684,10 +677,8 @@ func (m model) helpVisible() int {
 // never past it.
 func (m model) helpMaxOffset() int { return max(len(m.helpBody())-m.helpVisible(), 0) }
 
-// helpOverlay is the full-screen key cheatsheet (?). It is taller than a short
-// terminal — the whole point of it is to be exhaustive — so it scrolls rather
-// than being silently cut off at whatever row the terminal ends on, which is
-// what it used to do to its own second half.
+// helpOverlay is the full-screen key cheatsheet (?). It scrolls rather than
+// being cut off at whatever row a short terminal ends on.
 func (m model) helpOverlay() string {
 	lines := m.helpBody()
 	visible, total := m.helpVisible(), len(lines)

--- a/main.go
+++ b/main.go
@@ -322,14 +322,9 @@ func historyFile(disabled bool) string {
 }
 
 // keyConfigFile is where key bindings are read from: the dotfile first, then
-// the config directory netdoc already keeps history in. The dotfile wins
-// because it is the one a user puts in a dotfiles repo and expects to be in
-// charge, and because it is the only one of the two that is a dotfile on all
-// three platforms. Neither is ever written.
-//
-// "" is "no config", which is also what -no-config means and what an absent
-// file leaves behind, so the flag is that path taken on purpose rather than a
-// second opt-out mechanism.
+// the config directory netdoc already keeps history in. Neither is ever
+// written. "" is "no config", which is also what -no-config and an absent file
+// leave behind.
 func keyConfigFile(disabled bool) string {
 	if disabled {
 		return ""

--- a/main.go
+++ b/main.go
@@ -185,7 +185,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 	fs.Var(&checks, "check", "run stable probe IDs in `probe[,probe...]` form; repeatable")
 	fs.Var(&skips, "skip", "skip stable probe IDs in `probe[,probe...]` form; repeatable")
 	noHistory := fs.Bool("no-history", false, "don't read or write the saved target history")
-	keys := fs.String("keys", "default", "keybinding `preset` for the TUI: default or vim")
+	keys := fs.String("keys", "", "keybinding `preset` for the TUI: default or vim; overrides the config file")
+	noConfig := fs.Bool("no-config", false, "don't read the key bindings config file")
 	showVersion := fs.Bool("version", false, "print version and exit")
 	timeout := fs.Duration("timeout", diagnostic.ProbeTimeout, "per-check probe timeout")
 
@@ -268,10 +269,11 @@ func run(args []string, stdout, stderr io.Writer) int {
 	}
 	// Validated even for -json, where it changes nothing: a typo in a flag is
 	// worth hearing about on the run that carries it, not on the next one.
-	keymap, err := ui.PresetKeymap(*keys)
-	if err != nil {
-		fmt.Fprintln(stderr, "netdoc: -keys:", err)
-		return 2
+	if *keys != "" {
+		if _, err := ui.PresetKeymap(*keys); err != nil {
+			fmt.Fprintln(stderr, "netdoc: -keys:", err)
+			return 2
+		}
 	}
 
 	if *jsonOut {
@@ -281,8 +283,21 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// No mouse tracking: terminals translate the wheel to arrow keys in the
 	// alt screen (alternate scroll), and grabbing the mouse would break
 	// native text selection.
+	// A rejected config is reported twice on purpose. stderr is written before
+	// the alt screen takes over, so it is still on the terminal after netdoc
+	// exits — where a keymap gets fixed; the notice is what says so while the
+	// TUI is up and the scrollback is out of reach.
+	configPath := keyConfigFile(*noConfig)
+	keymap, keyErrs := ui.LoadKeymap(configPath, *keys)
+	opts := []ui.Option{ui.WithKeymap(keymap)}
+	if len(keyErrs) > 0 {
+		for _, err := range keyErrs {
+			fmt.Fprintf(stderr, "netdoc: %s: %v\n", configPath, err)
+		}
+		opts = append(opts, ui.WithStartupNotice(keyConfigNotice(configPath, keyErrs)))
+	}
 	p := tea.NewProgram(ui.NewWithSelection(t, sources, *toolbox, *watch, historyFile(*noHistory), version, *publicDNS, selection,
-		ui.WithKeymap(keymap)), tea.WithAltScreen())
+		opts...), tea.WithAltScreen())
 	final, err := p.Run()
 	// Every way out of Run lands here, including the ones that never reached
 	// the model's own quit path.
@@ -304,6 +319,48 @@ func historyFile(disabled bool) string {
 		return ""
 	}
 	return filepath.Join(dir, "netdoc", "history")
+}
+
+// keyConfigFile is where key bindings are read from: the dotfile first, then
+// the config directory netdoc already keeps history in. The dotfile wins
+// because it is the one a user puts in a dotfiles repo and expects to be in
+// charge, and because it is the only one of the two that is a dotfile on all
+// three platforms. Neither is ever written.
+//
+// "" is "no config", which is also what -no-config means and what an absent
+// file leaves behind, so the flag is that path taken on purpose rather than a
+// second opt-out mechanism.
+func keyConfigFile(disabled bool) string {
+	if disabled {
+		return ""
+	}
+	var candidates []string
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates, filepath.Join(home, ".netdocrc"))
+	}
+	if dir, err := os.UserConfigDir(); err == nil {
+		candidates = append(candidates, filepath.Join(dir, "netdoc", "config.yaml"))
+	}
+	for _, path := range candidates {
+		// Stat, not "read and see": a path that exists but can't be read is a
+		// problem worth reporting, not a reason to fall through to the other
+		// file and silently use different bindings.
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
+// keyConfigNotice is the one line the TUI shows about a rejected config. One
+// error is quoted; several are counted, because the bar is one line and the
+// full list is already on stderr.
+func keyConfigNotice(path string, errs []error) string {
+	where := filepath.Base(path)
+	if len(errs) == 1 {
+		return fmt.Sprintf("%s: %v — using the built-in keys", where, errs[0])
+	}
+	return fmt.Sprintf("%s: %d key binding errors — using the built-in keys", where, len(errs))
 }
 
 // printUsage writes the full help text: usage line, the target grammar

--- a/main.go
+++ b/main.go
@@ -185,6 +185,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	fs.Var(&checks, "check", "run stable probe IDs in `probe[,probe...]` form; repeatable")
 	fs.Var(&skips, "skip", "skip stable probe IDs in `probe[,probe...]` form; repeatable")
 	noHistory := fs.Bool("no-history", false, "don't read or write the saved target history")
+	keys := fs.String("keys", "default", "keybinding `preset` for the TUI: default or vim")
 	showVersion := fs.Bool("version", false, "print version and exit")
 	timeout := fs.Duration("timeout", diagnostic.ProbeTimeout, "per-check probe timeout")
 
@@ -265,6 +266,13 @@ func run(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "netdoc:", err)
 		return 2
 	}
+	// Validated even for -json, where it changes nothing: a typo in a flag is
+	// worth hearing about on the run that carries it, not on the next one.
+	keymap, err := ui.PresetKeymap(*keys)
+	if err != nil {
+		fmt.Fprintln(stderr, "netdoc: -keys:", err)
+		return 2
+	}
 
 	if *jsonOut {
 		return runJSON(context.Background(), t, sources, *watch, *publicDNS, selection, stdout, stderr)
@@ -273,7 +281,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// No mouse tracking: terminals translate the wheel to arrow keys in the
 	// alt screen (alternate scroll), and grabbing the mouse would break
 	// native text selection.
-	p := tea.NewProgram(ui.NewWithSelection(t, sources, *toolbox, *watch, historyFile(*noHistory), version, *publicDNS, selection), tea.WithAltScreen())
+	p := tea.NewProgram(ui.NewWithSelection(t, sources, *toolbox, *watch, historyFile(*noHistory), version, *publicDNS, selection,
+		ui.WithKeymap(keymap)), tea.WithAltScreen())
 	final, err := p.Run()
 	// Every way out of Run lands here, including the ones that never reached
 	// the model's own quit path.

--- a/main_test.go
+++ b/main_test.go
@@ -244,6 +244,49 @@ func TestHistoryFile(t *testing.T) {
 	}
 }
 
+// The two config locations and the order between them. Both are derived from
+// HOME here, so the same test pins the path on every platform's answer for
+// os.UserConfigDir.
+func TestKeyConfigFile(t *testing.T) {
+	if got := keyConfigFile(true); got != "" {
+		t.Errorf("keyConfigFile(true) = %q, want the empty path", got)
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+	if got := keyConfigFile(false); got != "" {
+		t.Errorf("keyConfigFile with no file = %q, want the empty path", got)
+	}
+
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		t.Skipf("no user config dir on this host: %v", err)
+	}
+	configYAML := filepath.Join(dir, "netdoc", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(configYAML), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configYAML, []byte("keys: vim\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := keyConfigFile(false); got != configYAML {
+		t.Errorf("keyConfigFile = %q, want %q", got, configYAML)
+	}
+
+	// The dotfile outranks it once it exists.
+	dotfile := filepath.Join(home, ".netdocrc")
+	if err := os.WriteFile(dotfile, []byte("keys: default\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := keyConfigFile(false); got != dotfile {
+		t.Errorf("keyConfigFile = %q, want the dotfile %q", got, dotfile)
+	}
+	if got := keyConfigFile(true); got != "" {
+		t.Errorf("-no-config still found %q", got)
+	}
+}
+
 // A misspelled preset is rejected before anything runs — including under
 // -json, where the keymap has no effect but the typo is still worth hearing
 // about on the run that carries it.

--- a/main_test.go
+++ b/main_test.go
@@ -244,6 +244,22 @@ func TestHistoryFile(t *testing.T) {
 	}
 }
 
+// A misspelled preset is rejected before anything runs — including under
+// -json, where the keymap has no effect but the typo is still worth hearing
+// about on the run that carries it.
+func TestRunRejectsUnknownKeyPreset(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"-keys", "emacs", "-json"}, &stdout, &stderr); code != 2 {
+		t.Errorf("run(-keys emacs) = %d, want 2", code)
+	}
+	if !strings.Contains(stderr.String(), "unknown key preset") || !strings.Contains(stderr.String(), "vim") {
+		t.Errorf("stderr = %q, want the rejection and the valid names", stderr.String())
+	}
+	if stdout.Len() > 0 {
+		t.Errorf("stdout = %q, want nothing", stdout.String())
+	}
+}
+
 // Drives the real -json path through run() with probe execution stubbed out,
 // pinning the headless contract: valid JSON on stdout, exit 1 iff a check failed.
 func TestRunJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

Added vim keybinds and configurable keymaps. Vim mode can be specified in the config file or by using the '--keys=vim' flag. Cheatsheet '?' command now works on all screens.

## Validation

Everything listed in the README.md and custom tests.

- [x] Tests nearest the change pass
- [x] Full validation gate passes, or exceptions are explained below
- [x] Cross-platform compile checks run when platform-specific code changed

## Platforms

MacOS Ventura

## TUI changes
