### PR TITLE
Document manual Debian package upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,15 @@ sudo apk add --allow-untrusted ./network-doctor_X.Y.Z_linux_amd64.apk    # Alpin
 ```
 
 These standalone packages do not add an update repository, so `dnf`/`apt`
-will not pull the next version for you.
+will not pull the next version for you. After downloading a newer Debian
+package, install it over the existing version and confirm the upgrade:
+
+```sh
+sudo apt install ./network-doctor_X.Y.Z_linux_amd64.deb
+netdoc --version
+netdoc-sim version
+dpkg-query -W network-doctor
+```
 
 Every Linux package (COPR, `.deb`, `.rpm`, `.apk`) installs two commands at the same version: `netdoc`, and `netdoc-sim`, the simulator behind [Challenge Mode](#think-you-can-beat-network-doctor). Confirm both:
 


### PR DESCRIPTION
## Summary

- I documented how to upgrade a manually downloaded Debian package after downloading the next release.
- I kept the existing warning that standalone packages do not configure an update repository.
- I included commands to verify both installed binaries and the package version after the upgrade.

## Validation

- [x] I installed the published `network-doctor_1.14.0_linux_amd64.deb` with `apt-get` in an isolated apt/dpkg root on Debian GNU/Linux 13 (trixie), amd64.
- [x] I verified `netdoc --version`, `netdoc-sim version`, and `dpkg-query -W network-doctor` all reported 1.14.0.
- [x] I installed the published 1.15.0 package over 1.14.0 in the same isolated root and verified both commands and dpkg reported 1.15.0.
- [x] I ran `python3 /tmp/subreaper.py go test -count=1 ./...` successfully. I used a local child-subreaper wrapper because this runner's PID 1 does not reap orphaned test helpers.
- [x] I ran `git diff --check origin/main...HEAD` successfully.

## Platforms

I tested the package transition on Debian GNU/Linux 13 (trixie), amd64. I did not test arm64 or Ubuntu.

## TUI changes

Not applicable.

Fixes #26
