### PR TITLE
Check completion script syntax in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,21 @@ jobs:
           persist-credentials: false
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
 
+  completion-syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install completion shells
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y fish zsh
+      - name: Check completion script syntax
+        run: |
+          set -euo pipefail
+          for script in packaging/completions/*.bash; do bash -n "$script"; done
+          for script in packaging/completions/*.zsh; do zsh -n "$script"; done
+          for script in packaging/completions/*.fish; do fish -n "$script"; done
+
   test:
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -420,6 +420,19 @@ go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
 go run github.com/goreleaser/goreleaser/v2@v2.17.1 check
 ```
 
+CI also syntax-checks every shipped Bash, Zsh, and Fish completion script with
+its native shell. Run the same focused check after changing a file under
+`packaging/completions/`:
+
+```sh
+(
+  set -e
+  for script in packaging/completions/*.bash; do bash -n "$script"; done
+  for script in packaging/completions/*.zsh; do zsh -n "$script"; done
+  for script in packaging/completions/*.fish; do fish -n "$script"; done
+)
+```
+
 If the change touched the `Dockerfile` or the image's release job, also build the
 image and test the artifact. It needs Docker or Podman, which is why it is not in
 the gate above:


### PR DESCRIPTION
Closes #45.

This adds a focused Ubuntu CI job that installs Zsh and Fish, then syntax-checks every shipped Bash, Zsh, and Fish completion file with its native shell. The glob-based checks automatically include future completion files. The README now records the same focused validation command.

Validation:

- all six completion scripts passed in an Ubuntu 24.04 container
- an unmatched Fish `end` made the syntax gate fail as expected
- `go test ./...`
- `go test . -run 'Test(?:READMEValidationToolVersionsMatchCI|NoEmDashInTrackedTextFiles)$' -count=1`
- Actionlint passed after ignoring its outdated warning for the existing `ubuntu-26.04` runner label
- `git diff --check`

AI assistance: I used Codex to inspect the existing CI and draft the change, then ran the positive and negative checks above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated syntax checks for Bash, Zsh, and Fish completion scripts.

* **Documentation**
  * Added guidance for validating completion scripts, including a focused shell-check command for changes to completion files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->