### PR TITLE
Add scripts/check, one fast local gate for an ordinary pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
+      # The contributor-facing fast gate, run on Linux so it cannot rot
+      # unnoticed. It is a subset of the steps below, so the cost is a few
+      # seconds; the point is that `scripts/check` is known to still work.
+      - if: runner.os == 'Linux'
+        name: Run the fast local check contributors are asked to run
+        run: ./scripts/check
       - run: go vet ./...
       - run: go build ./...
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,11 @@ jobs:
         with:
           go-version-file: go.mod
       # The contributor-facing fast gate, run on Linux so it cannot rot
-      # unnoticed. It is a subset of the steps below, so the cost is a few
-      # seconds; the point is that `scripts/check` is known to still work.
+      # unnoticed. Most of its work is repeated by the steps below, so this
+      # roughly doubles the unit suite on this leg rather than costing a few
+      # seconds. That is the price of the guarantee: contributors are told to
+      # run `scripts/check`, and running the real script is the only thing that
+      # proves it still works. Asserting on its text cannot.
       - if: runner.os == 'Linux'
         name: Run the fast local check contributors are asked to run
         run: ./scripts/check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,11 +87,16 @@ For an ordinary, focused pull request, run:
 ```
 
 That is gofmt, `go vet`, a `CGO_ENABLED=0` build, a macOS and Windows
-cross-compile, and `go test ./...`. It needs a Go toolchain and a POSIX shell:
-no root, no network, no Docker. On Windows that shell is the Git Bash that
-ships with Git for Windows, or WSL; the checks themselves are the same three
+cross-compile, and `go test ./...`. It needs a Go toolchain and a POSIX shell,
+and no root and no Docker. On Windows that shell is the Git Bash that ships
+with Git for Windows, or WSL; the checks themselves are the same three
 platforms over. Add `--race` to include the race detector. CI runs the same
 script on Linux, so it cannot rot without someone noticing.
+
+The checks make no network calls themselves, but the Go toolchain may: a cold
+or incomplete module cache downloads this module's dependencies, and a Go
+older than the `toolchain` line in `go.mod` downloads that toolchain first.
+Warm both once (`go mod download`) and the script runs offline after that.
 
 Then run the tests nearest your change and anything else clearly relevant to
 the files or behavior you touched.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,13 +80,28 @@ that command would delete too.
 
 ## Validation
 
-Start with the tests nearest your change, then `go test ./...` and any other
-checks clearly relevant to the files or behavior you changed. That is enough
-for an ordinary, focused pull request. Run the rest of the
-[README](README.md#tests) gate only where a specific check applies to your
-change, for CI, maintainership, releases, or a check that genuinely matters to
-what you touched; a small external contribution does not have to reproduce every
-CI environment locally.
+For an ordinary, focused pull request, run:
+
+```sh
+./scripts/check
+```
+
+That is gofmt, `go vet`, a `CGO_ENABLED=0` build, a macOS and Windows
+cross-compile, and `go test ./...`. It needs only a Go toolchain: no root, no
+network, no Docker, and it behaves the same on Linux, macOS and Windows. Add
+`--race` to include the race detector. CI runs the same script on Linux, so it
+cannot rot without someone noticing.
+
+Then run the tests nearest your change and anything else clearly relevant to
+the files or behavior you touched.
+
+**What the script leaves to CI, and why:** the race, fuzz, loopback-integration,
+namespace, acceptance and container suites, plus the pinned external tools
+(golangci-lint, govulncheck, goreleaser). Those are slower, several need Linux
+or Docker, and the pinned tools download on first run. Running the rest of the
+[README](README.md#tests) gate locally is worth it where a specific check
+applies to your change, for CI, maintainership, or releases; a small external
+contribution does not have to reproduce every CI environment.
 
 Additional requirements:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,10 +87,11 @@ For an ordinary, focused pull request, run:
 ```
 
 That is gofmt, `go vet`, a `CGO_ENABLED=0` build, a macOS and Windows
-cross-compile, and `go test ./...`. It needs only a Go toolchain: no root, no
-network, no Docker, and it behaves the same on Linux, macOS and Windows. Add
-`--race` to include the race detector. CI runs the same script on Linux, so it
-cannot rot without someone noticing.
+cross-compile, and `go test ./...`. It needs a Go toolchain and a POSIX shell:
+no root, no network, no Docker. On Windows that shell is the Git Bash that
+ships with Git for Windows, or WSL; the checks themselves are the same three
+platforms over. Add `--race` to include the race detector. CI runs the same
+script on Linux, so it cannot rot without someone noticing.
 
 Then run the tests nearest your change and anything else clearly relevant to
 the files or behavior you touched.

--- a/README.md
+++ b/README.md
@@ -391,9 +391,10 @@ the software or how issues are prioritized.
 
 ## Tests
 
-For an ordinary, focused pull request, run the tests nearest your change plus
-`go test ./...`, then any additional checks clearly relevant to the files or
-behavior you changed. That is almost all a small external contribution needs.
+For an ordinary, focused pull request, run `./scripts/check` -- gofmt, `go vet`,
+a `CGO_ENABLED=0` build, macOS and Windows cross-compiles, and `go test ./...`,
+with no root, network or Docker needed -- then the tests nearest your change and
+any additional checks clearly relevant to the files or behavior you changed. That is almost all a small external contribution needs.
 The exhaustive gate below exists for CI, maintainership, releases, and the
 specific checks that apply to your change; a small contribution does not have
 to reproduce every CI environment locally.

--- a/README.md
+++ b/README.md
@@ -393,7 +393,8 @@ the software or how issues are prioritized.
 
 For an ordinary, focused pull request, run `./scripts/check` -- gofmt, `go vet`,
 a `CGO_ENABLED=0` build, macOS and Windows cross-compiles, and `go test ./...`,
-with no root, network or Docker needed -- then the tests nearest your change and
+with no root, network or Docker needed (a Go toolchain and a POSIX shell: on
+Windows, Git Bash or WSL) -- then the tests nearest your change and
 any additional checks clearly relevant to the files or behavior you changed. That is almost all a small external contribution needs.
 The exhaustive gate below exists for CI, maintainership, releases, and the
 specific checks that apply to your change; a small contribution does not have

--- a/README.md
+++ b/README.md
@@ -393,9 +393,12 @@ the software or how issues are prioritized.
 
 For an ordinary, focused pull request, run `./scripts/check` -- gofmt, `go vet`,
 a `CGO_ENABLED=0` build, macOS and Windows cross-compiles, and `go test ./...`,
-with no root, network or Docker needed (a Go toolchain and a POSIX shell: on
-Windows, Git Bash or WSL) -- then the tests nearest your change and
-any additional checks clearly relevant to the files or behavior you changed. That is almost all a small external contribution needs.
+with no root and no Docker needed (a Go toolchain and a POSIX shell: on
+Windows, Git Bash or WSL). The checks make no network calls, though the Go
+toolchain downloads on a cold module cache or an out-of-date `toolchain` line.
+Then run the tests nearest your change and any additional checks clearly
+relevant to the files or behavior you changed. That is almost all a small
+external contribution needs.
 The exhaustive gate below exists for CI, maintainership, releases, and the
 specific checks that apply to your change; a small contribution does not have
 to reproduce every CI environment locally.

--- a/check_script_test.go
+++ b/check_script_test.go
@@ -71,6 +71,55 @@ func TestCheckScriptRunsTheFastChecksItDocuments(t *testing.T) {
 	}
 }
 
+func TestCheckScriptRunsTheOptionalModesItDocuments(t *testing.T) {
+	// --race and the help aliases are part of the documented command, and the
+	// test above would stay green if any of them were dropped: they are not
+	// among the checks it runs by default.
+	script := readCheckScriptCode(t)
+	for _, want := range []string{
+		"--race) race=1",
+		"go test -race ./...",
+		"-h | --help)",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("%s no longer handles %q", checkScript, want)
+		}
+	}
+}
+
+func TestCheckScriptUsageMatchesTheOptionsItAccepts(t *testing.T) {
+	// The help output is a slice of this file's own header comment, so an
+	// option can be added to the parser and never reach the usage text.
+	script := readCheckScript(t)
+	header, _, ok := strings.Cut(script, "\nset -eu")
+	if !ok {
+		t.Fatal("cannot find the end of the header comment")
+	}
+	for _, want := range []string{"./scripts/check", "--race"} {
+		if !strings.Contains(header, want) {
+			t.Errorf("the usage text printed by --help does not mention %q", want)
+		}
+	}
+}
+
+func TestContributingStatesWhatTheCheckScriptNeedsToRun(t *testing.T) {
+	// The script is #!/bin/sh, so a Go toolchain alone is not enough on
+	// Windows. Saying otherwise sends a contributor looking for a bug in
+	// their setup.
+	body, err := os.ReadFile("CONTRIBUTING.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := string(body)
+	if !strings.Contains(doc, "POSIX shell") {
+		t.Error("CONTRIBUTING.md does not say the script needs a POSIX shell")
+	}
+	if strings.Contains(doc, "it behaves the same on Linux, macOS and Windows") {
+		t.Error("CONTRIBUTING.md claims the script runs the same everywhere; " +
+			"a Windows contributor needs Git Bash or WSL to run /bin/sh")
+	}
+}
+
 func TestCheckScriptLeavesTheExpensiveGateToCI(t *testing.T) {
 	// The value of a fast check is that it is fast. If one of these ever moves
 	// into it, that should be a deliberate edit to this list rather than a

--- a/check_script_test.go
+++ b/check_script_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The fast contributor gate is a shell script, so nothing the Go build does
+// would notice it rotting. These tests pin the parts that would rot silently:
+// the file's existence and executable bit, the checks it is documented to run,
+// the ones it is documented to leave to CI, and the fact that CI runs it.
+//
+// They deliberately assert on the script's content rather than executing it.
+// Running it from a test would recurse: the script's own `go test ./...` step
+// runs this file.
+
+const checkScript = "scripts/check"
+
+func readCheckScript(t *testing.T) string {
+	t.Helper()
+	body, err := os.ReadFile(checkScript)
+	if err != nil {
+		t.Fatalf("read %s: %v", checkScript, err)
+	}
+	return string(body)
+}
+
+// readCheckScriptCode returns the script with comment lines removed, so an
+// assertion that a command is absent is not satisfied or defeated by prose.
+// The script explains what it leaves to CI by naming those tools, and a naive
+// substring search over the whole file reads that explanation as a call.
+func readCheckScriptCode(t *testing.T) string {
+	t.Helper()
+	var code strings.Builder
+	for _, line := range strings.Split(readCheckScript(t), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		code.WriteString(line)
+		code.WriteByte('\n')
+	}
+	return code.String()
+}
+
+func TestCheckScriptExistsAndIsExecutable(t *testing.T) {
+	info, err := os.Stat(checkScript)
+	if err != nil {
+		t.Fatalf("stat %s: %v", checkScript, err)
+	}
+	// Checked through git rather than the filesystem mode, because a Windows
+	// checkout does not carry the bit but the committed tree must.
+	if info.Mode().IsRegular() && info.Size() == 0 {
+		t.Fatalf("%s is empty", checkScript)
+	}
+}
+
+func TestCheckScriptRunsTheFastChecksItDocuments(t *testing.T) {
+	script := readCheckScriptCode(t)
+	for _, want := range []string{
+		"gofmt -l .",
+		"go vet ./...",
+		"CGO_ENABLED=0 go build ./...",
+		"GOOS=darwin go build ./...",
+		"GOOS=windows go build ./...",
+		"go test ./...",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("%s no longer runs %q", checkScript, want)
+		}
+	}
+}
+
+func TestCheckScriptLeavesTheExpensiveGateToCI(t *testing.T) {
+	// The value of a fast check is that it is fast. If one of these ever moves
+	// into it, that should be a deliberate edit to this list rather than a
+	// contributor quietly discovering the script now takes ten minutes.
+	script := readCheckScriptCode(t)
+	for _, unwanted := range []string{
+		"-tags integration",
+		"-tags netns_integration",
+		"-tags acceptance",
+		"-tags container",
+		"-fuzz=",
+		"golangci-lint",
+		"govulncheck",
+		"goreleaser",
+	} {
+		if strings.Contains(script, unwanted) {
+			t.Errorf("%s runs %q, which belongs in CI: it is slow, "+
+				"platform-specific, or needs the network", checkScript, unwanted)
+		}
+	}
+}
+
+func TestCheckScriptNeedsNoPrivileges(t *testing.T) {
+	script := readCheckScriptCode(t)
+	for _, unwanted := range []string{"sudo", "sysctl", "docker ", "podman "} {
+		if strings.Contains(script, unwanted) {
+			t.Errorf("%s uses %q; the fast check must run unprivileged and "+
+				"without a container runtime", checkScript, unwanted)
+		}
+	}
+}
+
+func TestContinuousIntegrationRunsTheCheckScript(t *testing.T) {
+	// Without this the script is documentation that compiles nothing: it could
+	// break and no contributor would find out until they ran it.
+	workflow, err := os.ReadFile(".github/workflows/ci.yml")
+	if err != nil {
+		t.Fatalf("read ci.yml: %v", err)
+	}
+	if !strings.Contains(string(workflow), "./"+checkScript) {
+		t.Fatalf("ci.yml does not run ./%s, so it can rot unnoticed", checkScript)
+	}
+}
+
+func TestContributingAndREADMEPointAtTheCheckScript(t *testing.T) {
+	for _, doc := range []string{"CONTRIBUTING.md", "README.md"} {
+		body, err := os.ReadFile(doc)
+		if err != nil {
+			t.Fatalf("read %s: %v", doc, err)
+		}
+		if !strings.Contains(string(body), checkScript) {
+			t.Errorf("%s does not mention %s", doc, checkScript)
+		}
+	}
+}

--- a/check_script_test.go
+++ b/check_script_test.go
@@ -2,23 +2,27 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 )
 
 // The fast contributor gate is a shell script, so nothing the Go build does
 // would notice it rotting. These tests pin the parts that would rot silently:
-// the file's existence and executable bit, the checks it is documented to run,
-// the ones it is documented to leave to CI, and the fact that CI runs it.
+// its committed executable mode, the checks it is documented to run, the ones
+// it is documented to leave to CI, that --race stays opt-in, that --help still
+// describes the options the parser accepts, and that CI runs the script.
 //
-// They deliberately assert on the script's content rather than executing it.
-// Running it from a test would recurse: the script's own `go test ./...` step
-// runs this file.
+// They assert on the script's content rather than running it, with one
+// exception: --help is checked by executing it, which is safe because usage()
+// prints and exits before the first check step. Running the script bare from a
+// test would recurse, because its own `go test ./...` step runs this file.
 
 const checkScript = "scripts/check"
 
 func readCheckScript(t *testing.T) string {
 	t.Helper()
+	// #nosec G304 -- checkScript is this file's own constant, not input.
 	body, err := os.ReadFile(checkScript)
 	if err != nil {
 		t.Fatalf("read %s: %v", checkScript, err)
@@ -26,15 +30,31 @@ func readCheckScript(t *testing.T) string {
 	return string(body)
 }
 
-// readCheckScriptCode returns the script with comment lines removed, so an
-// assertion that a command is absent is not satisfied or defeated by prose.
-// The script explains what it leaves to CI by naming those tools, and a naive
-// substring search over the whole file reads that explanation as a call.
+// readCheckScriptCode returns the script with comment lines and the usage()
+// here-document removed, so an assertion that a command is absent is not
+// satisfied or defeated by prose. The script explains what it leaves to CI by
+// naming those tools, in both places, and a naive substring search over the
+// whole file reads that explanation as a call.
 func readCheckScriptCode(t *testing.T) string {
 	t.Helper()
 	var code strings.Builder
+	inUsage := false
 	for _, line := range strings.Split(readCheckScript(t), "\n") {
-		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+		trimmed := strings.TrimSpace(line)
+		// The usage() here-document is prose for the same reason a comment
+		// is: it names the tools the script leaves to CI in order to explain
+		// the split, and a substring search would read those names as calls.
+		if strings.HasPrefix(trimmed, "cat <<") {
+			inUsage = true
+			continue
+		}
+		if inUsage {
+			if trimmed == "EOF" {
+				inUsage = false
+			}
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") {
 			continue
 		}
 		code.WriteString(line)
@@ -43,15 +63,22 @@ func readCheckScriptCode(t *testing.T) string {
 	return code.String()
 }
 
-func TestCheckScriptExistsAndIsExecutable(t *testing.T) {
-	info, err := os.Stat(checkScript)
+func TestCheckScriptIsCommittedExecutable(t *testing.T) {
+	// The documented invocation is `./scripts/check`, which needs the execute
+	// bit in the committed tree. The filesystem mode cannot be asserted here:
+	// a Windows checkout does not carry it. git's index does, so ask git.
+	out, err := exec.Command("git", "ls-files", "--stage", "--", checkScript).Output()
 	if err != nil {
-		t.Fatalf("stat %s: %v", checkScript, err)
+		t.Skipf("git unavailable, or this is not a checkout: %v", err)
 	}
-	// Checked through git rather than the filesystem mode, because a Windows
-	// checkout does not carry the bit but the committed tree must.
-	if info.Mode().IsRegular() && info.Size() == 0 {
-		t.Fatalf("%s is empty", checkScript)
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		t.Fatalf("%s is not tracked by git", checkScript)
+	}
+	if fields[0] != "100755" {
+		t.Errorf("%s is committed as mode %s, want 100755: ./%s would not be "+
+			"directly executable for a contributor who just cloned",
+			checkScript, fields[0], checkScript)
 	}
 }
 
@@ -87,18 +114,56 @@ func TestCheckScriptRunsTheOptionalModesItDocuments(t *testing.T) {
 	}
 }
 
-func TestCheckScriptUsageMatchesTheOptionsItAccepts(t *testing.T) {
-	// The help output is a slice of this file's own header comment, so an
-	// option can be added to the parser and never reach the usage text.
-	script := readCheckScript(t)
-	header, _, ok := strings.Cut(script, "\nset -eu")
+func TestCheckScriptKeepsTheRaceDetectorOptIn(t *testing.T) {
+	// The point of the fast check is that it is fast, and -race roughly
+	// doubles it. Asserting only that `go test -race ./...` appears somewhere
+	// stays green if it is promoted into the default path, so pin that it
+	// sits inside the `if [ "$race" -eq 1 ]` guard and nowhere else.
+	script := readCheckScriptCode(t)
+	const guard = `if [ "$race" -eq 1 ]; then`
+	beforeGuard, afterGuard, ok := strings.Cut(script, guard)
 	if !ok {
-		t.Fatal("cannot find the end of the header comment")
+		t.Fatalf("%s no longer guards the race step with %q", checkScript, guard)
 	}
-	for _, want := range []string{"./scripts/check", "--race"} {
-		if !strings.Contains(header, want) {
-			t.Errorf("the usage text printed by --help does not mention %q", want)
+	guarded, _, ok := strings.Cut(afterGuard, "\nfi")
+	if !ok {
+		t.Fatalf("%s: the %q block is never closed", checkScript, guard)
+	}
+	if !strings.Contains(guarded, "go test -race ./...") {
+		t.Errorf("%s no longer runs the race detector inside the --race guard", checkScript)
+	}
+	if strings.Contains(beforeGuard, "go test -race") {
+		t.Errorf("%s runs the race detector before the --race guard, so it is "+
+			"no longer opt-in and the fast check is no longer fast", checkScript)
+	}
+}
+
+func TestCheckScriptUsageMatchesTheOptionsItAccepts(t *testing.T) {
+	// Assert on what --help actually prints rather than on a slice of the
+	// file, so adding a header line cannot change the help text without
+	// this test noticing, and an option cannot be added to the parser
+	// without reaching the usage text.
+	//
+	// Running --help does not recurse the way running the script bare would:
+	// usage() prints and exits before the first check step.
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("no POSIX shell on this machine: %v", err)
+	}
+	out, err := exec.Command(sh, checkScript, "--help").CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s --help: %v\n%s", checkScript, err, out)
+	}
+	help := string(out)
+	for _, want := range []string{"./scripts/check", "--race", "--help"} {
+		if !strings.Contains(help, want) {
+			t.Errorf("the usage text printed by --help does not mention %q:\n%s", want, help)
 		}
+	}
+	// The network caveat is what a contributor on a cold module cache is
+	// most likely to be bitten by, so it has to survive a header edit too.
+	if !strings.Contains(help, "Network:") {
+		t.Errorf("--help no longer says when the Go toolchain needs the network:\n%s", help)
 	}
 }
 
@@ -106,6 +171,7 @@ func TestContributingStatesWhatTheCheckScriptNeedsToRun(t *testing.T) {
 	// The script is #!/bin/sh, so a Go toolchain alone is not enough on
 	// Windows. Saying otherwise sends a contributor looking for a bug in
 	// their setup.
+	// #nosec G304 -- a string literal, not input.
 	body, err := os.ReadFile("CONTRIBUTING.md")
 	if err != nil {
 		t.Fatal(err)
@@ -155,6 +221,7 @@ func TestCheckScriptNeedsNoPrivileges(t *testing.T) {
 func TestContinuousIntegrationRunsTheCheckScript(t *testing.T) {
 	// Without this the script is documentation that compiles nothing: it could
 	// break and no contributor would find out until they ran it.
+	// #nosec G304 -- a string literal, not input.
 	workflow, err := os.ReadFile(".github/workflows/ci.yml")
 	if err != nil {
 		t.Fatalf("read ci.yml: %v", err)
@@ -166,6 +233,7 @@ func TestContinuousIntegrationRunsTheCheckScript(t *testing.T) {
 
 func TestContributingAndREADMEPointAtTheCheckScript(t *testing.T) {
 	for _, doc := range []string{"CONTRIBUTING.md", "README.md"} {
+		// #nosec G304 -- doc comes from the fixed list on the line above.
 		body, err := os.ReadFile(doc)
 		if err != nil {
 			t.Fatalf("read %s: %v", doc, err)

--- a/check_script_test.go
+++ b/check_script_test.go
@@ -22,7 +22,6 @@ const checkScript = "scripts/check"
 
 func readCheckScript(t *testing.T) string {
 	t.Helper()
-	// #nosec G304 -- checkScript is this file's own constant, not input.
 	body, err := os.ReadFile(checkScript)
 	if err != nil {
 		t.Fatalf("read %s: %v", checkScript, err)
@@ -85,7 +84,7 @@ func TestCheckScriptIsCommittedExecutable(t *testing.T) {
 func TestCheckScriptRunsTheFastChecksItDocuments(t *testing.T) {
 	script := readCheckScriptCode(t)
 	for _, want := range []string{
-		"gofmt -l .",
+		"gofmt -l",
 		"go vet ./...",
 		"CGO_ENABLED=0 go build ./...",
 		"GOOS=darwin go build ./...",
@@ -95,6 +94,19 @@ func TestCheckScriptRunsTheFastChecksItDocuments(t *testing.T) {
 		if !strings.Contains(script, want) {
 			t.Errorf("%s no longer runs %q", checkScript, want)
 		}
+	}
+}
+
+func TestCheckScriptTakesTheGofmtFileListFromGit(t *testing.T) {
+	// gofmt walks every directory that does not start with "." or "_", so a
+	// bare `gofmt -l .` also reports node_modules and the vendor/ tree a local
+	// goreleaser run leaves behind: untracked third-party sources that
+	// `go build ./...` and golangci-lint both skip. That failed the gate on
+	// code no contributor can fix, so the file list comes from git.
+	script := readCheckScriptCode(t)
+	if !strings.Contains(script, "git ls-files") {
+		t.Errorf("%s no longer takes the gofmt file list from git, so it can "+
+			"fail on untracked vendor/ or node_modules/ sources", checkScript)
 	}
 }
 
@@ -146,11 +158,10 @@ func TestCheckScriptUsageMatchesTheOptionsItAccepts(t *testing.T) {
 	//
 	// Running --help does not recurse the way running the script bare would:
 	// usage() prints and exits before the first check step.
-	sh, err := exec.LookPath("sh")
-	if err != nil {
+	if _, err := exec.LookPath("sh"); err != nil {
 		t.Skipf("no POSIX shell on this machine: %v", err)
 	}
-	out, err := exec.Command(sh, checkScript, "--help").CombinedOutput()
+	out, err := exec.Command("sh", checkScript, "--help").CombinedOutput()
 	if err != nil {
 		t.Fatalf("%s --help: %v\n%s", checkScript, err, out)
 	}
@@ -171,7 +182,6 @@ func TestContributingStatesWhatTheCheckScriptNeedsToRun(t *testing.T) {
 	// The script is #!/bin/sh, so a Go toolchain alone is not enough on
 	// Windows. Saying otherwise sends a contributor looking for a bug in
 	// their setup.
-	// #nosec G304 -- a string literal, not input.
 	body, err := os.ReadFile("CONTRIBUTING.md")
 	if err != nil {
 		t.Fatal(err)
@@ -221,7 +231,6 @@ func TestCheckScriptNeedsNoPrivileges(t *testing.T) {
 func TestContinuousIntegrationRunsTheCheckScript(t *testing.T) {
 	// Without this the script is documentation that compiles nothing: it could
 	// break and no contributor would find out until they ran it.
-	// #nosec G304 -- a string literal, not input.
 	workflow, err := os.ReadFile(".github/workflows/ci.yml")
 	if err != nil {
 		t.Fatalf("read ci.yml: %v", err)

--- a/scripts/check
+++ b/scripts/check
@@ -1,31 +1,45 @@
 #!/bin/sh
-# Fast local validation for an ordinary pull request.
-#
-# Runs the checks a contributor should have run before opening one: the ones
-# that are fast, need no privileges, need no network, and behave the same on
-# every platform a contributor might be on.
-#
-# It deliberately does NOT reproduce the full gate in README.md#tests. Race,
-# fuzz, loopback-integration, namespace, acceptance and container suites, and
-# the pinned external tools (golangci-lint, govulncheck, goreleaser), all stay
-# in CI. Those are slower, several need Linux or Docker, and the pinned tools
-# download on first run. Making this script the whole gate would make it too
-# slow to run, which is the way a check like this stops being run at all.
-#
-# Usage:
-#   ./scripts/check            fast checks
-#   ./scripts/check --race     also run the race detector (slower, still local)
+# Fast local validation for an ordinary pull request. See usage() below.
 #
 # Exits non-zero on the first failure, so it is usable in a pre-push hook.
 
 set -eu
+
+# The help text is a here-document rather than a slice of this comment block,
+# so editing the header cannot silently change what --help prints.
+usage() {
+    cat <<'EOF'
+Fast local validation for an ordinary pull request.
+
+Runs the checks a contributor should have run before opening one: the ones
+that are fast, need no privileges, and behave the same on every platform a
+contributor might be on.
+
+Network: the checks themselves make no network calls, but the Go toolchain
+may. A cold or incomplete module cache downloads the module dependencies, and
+a Go older than the toolchain line in go.mod downloads that toolchain first.
+Once both are warm the script is offline.
+
+It deliberately does NOT reproduce the full gate in README.md#tests. Race,
+fuzz, loopback-integration, namespace, acceptance and container suites, and
+the pinned external tools (golangci-lint, govulncheck, goreleaser), all stay
+in CI. Those are slower, several need Linux or Docker, and the pinned tools
+download on first run. Making this script the whole gate would make it too
+slow to run, which is the way a check like this stops being run at all.
+
+Usage:
+  ./scripts/check            fast checks
+  ./scripts/check --race     also run the race detector (slower, still local)
+  ./scripts/check --help     print this message
+EOF
+}
 
 race=0
 for arg in "$@"; do
     case "$arg" in
         --race) race=1 ;;
         -h | --help)
-            sed -n '2,19p' "$0" | sed 's/^# \{0,1\}//'
+            usage
             exit 0
             ;;
         *)

--- a/scripts/check
+++ b/scripts/check
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Fast local validation for an ordinary pull request.
+#
+# Runs the checks a contributor should have run before opening one: the ones
+# that are fast, need no privileges, need no network, and behave the same on
+# every platform a contributor might be on.
+#
+# It deliberately does NOT reproduce the full gate in README.md#tests. Race,
+# fuzz, loopback-integration, namespace, acceptance and container suites, and
+# the pinned external tools (golangci-lint, govulncheck, goreleaser), all stay
+# in CI. Those are slower, several need Linux or Docker, and the pinned tools
+# download on first run. Making this script the whole gate would make it too
+# slow to run, which is the way a check like this stops being run at all.
+#
+# Usage:
+#   ./scripts/check            fast checks
+#   ./scripts/check --race     also run the race detector (slower, still local)
+#
+# Exits non-zero on the first failure, so it is usable in a pre-push hook.
+
+set -eu
+
+race=0
+for arg in "$@"; do
+    case "$arg" in
+        --race) race=1 ;;
+        -h | --help)
+            sed -n '2,19p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            printf 'check: unknown option %s\n' "$arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+cd "$(dirname "$0")/.."
+
+step() {
+    printf '\n==> %s\n' "$1"
+    shift
+    "$@"
+}
+
+# gofmt rather than `go fmt`: it reports rather than rewrites, so a formatting
+# problem fails the check instead of silently editing the working tree during
+# what the contributor asked to be a read-only verification.
+check_gofmt() {
+    unformatted=$(gofmt -l .)
+    if [ -n "$unformatted" ]; then
+        printf 'These files are not gofmt-clean:\n%s\n' "$unformatted" >&2
+        return 1
+    fi
+}
+
+step "gofmt" check_gofmt
+step "go vet" go vet ./...
+
+# CGO_ENABLED=0 matches the release build, so a cgo dependency introduced by
+# accident fails here rather than at release time. See AGENTS.md.
+step "build (CGO_ENABLED=0)" env CGO_ENABLED=0 go build ./...
+
+# Cross-compilation only, no tests: it is the cheap half of the cross-platform
+# rule in AGENTS.md, and it catches a platform-tagged file that does not
+# compile elsewhere. Running it always rather than only after a _linux/_darwin/
+# _windows edit costs a few seconds and removes the judgement call.
+step "cross-compile (darwin)" env GOOS=darwin go build ./...
+step "cross-compile (windows)" env GOOS=windows go build ./...
+
+# The ordinary suite: deterministic, rootless, no build tags. This is also
+# where the repository's own invariant tests live (architecture, packaging,
+# docs links, em dashes), so those run here too.
+step "go test" go test ./...
+
+if [ "$race" -eq 1 ]; then
+    step "go test -race" go test -race ./...
+fi
+
+printf '\nAll checks passed.\n'

--- a/scripts/check
+++ b/scripts/check
@@ -60,8 +60,16 @@ step() {
 # gofmt rather than `go fmt`: it reports rather than rewrites, so a formatting
 # problem fails the check instead of silently editing the working tree during
 # what the contributor asked to be a read-only verification.
+#
+# The file list comes from git rather than from `gofmt -l .`, because gofmt
+# walks every directory that does not start with "." or "_". That includes
+# untracked third-party trees `go build ./...` and golangci-lint both skip:
+# node_modules, and the vendor/ directory a local goreleaser run leaves behind
+# (see the before-hooks in .goreleaser.yaml). Reporting those fails the gate on
+# code no contributor can fix. -z and xargs -0 so the list survives a path with
+# a space in it.
 check_gofmt() {
-    unformatted=$(gofmt -l .)
+    unformatted=$(git ls-files -z '*.go' | xargs -0 gofmt -l)
     if [ -n "$unformatted" ]; then
         printf 'These files are not gofmt-clean:\n%s\n' "$unformatted" >&2
         return 1


### PR DESCRIPTION
Closes #39.

**User-visible effect:** one documented command from the repository root.

```sh
./scripts/check          # gofmt, go vet, CGO_ENABLED=0 build, darwin + windows cross-compile, go test ./...
./scripts/check --race   # the above plus the race detector
./scripts/check --help
```

Against the "Done when" list:

| requirement | how |
| --- | --- |
| one documented command from the root | `./scripts/check`, in CONTRIBUTING and README |
| fails when an included check fails | `set -eu`, exits on the first failure, so it works in a pre-push hook |
| fast enough for edit/test | no build tags, no external downloads; the slowest step is the ordinary `go test ./...` |
| no root | asserted by a test that rejects `sudo`/`sysctl` in the script |
| no macOS or Windows required | POSIX `sh`, Go toolchain only |
| no privileged namespace/integration suites unless asked | no build tags at all; `--race` is the only opt-in |
| does not weaken the full gate | the README gate is unchanged; this is a strict subset |
| CONTRIBUTING explains local vs CI | new Validation section, with the reason for each exclusion |
| enough CI coverage not to rot | CI runs `./scripts/check` on Linux, plus six guard tests |

**Two decisions worth flagging.**

`gofmt -l` rather than `go fmt`. `go fmt` rewrites the working tree, and a contributor running a script called `check` should not have their files edited as a side effect. This reports and fails.

The cross-compiles run **every time**, not only after a `_linux`/`_darwin`/`_windows` edit. AGENTS.md makes that conditional on the change, but the condition is a judgement call that is easy to get wrong from inside a diff, and the two builds cost seconds. Removing the judgement call seemed worth more than the seconds.

**Kept out, deliberately:** race (opt-in), fuzz, `integration`, `netns_integration`, `acceptance`, `container`, and the pinned `golangci-lint` / `govulncheck` / `goreleaser` runs. Slower, several need Linux or Docker, and the pinned tools download on first invocation. A gate too slow to run is one that stops being run, which would defeat the issue.

**Rot protection**, since a shell script is invisible to the Go build:

- CI runs `./scripts/check` on the Linux leg of the existing `test` job.
- `check_script_test.go` pins the checks it must run, the eight it must not, that it stays unprivileged and container-free, that CI still invokes it, and that both docs still reference it.

Those assertions read the script **with comment lines stripped** — worth mentioning because it caught a real bug while I wrote it. The script names `golangci-lint`, `govulncheck` and `goreleaser` in a comment explaining why they are absent, and a naive substring search read that explanation as a call and failed.

**Validation run:** `gofmt -l .` clean, `go vet ./...`, `CGO_ENABLED=0 go build ./...`, `GOOS=darwin go build ./...`, `GOOS=windows go build ./...` all pass; `go test .` (root invariants, including `TestNoEmDashInTrackedTextFiles`) passes, as do the new guards. Mutation-checked both directions: appending `go test -tags integration ...` to the script fails `TestCheckScriptLeavesTheExpensiveGateToCI`, and deleting the `go vet` step fails `TestCheckScriptRunsTheFastChecksItDocuments`.

`scripts/check` is committed mode `100755`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fast local validation command covering formatting, vetting, builds, cross-compilation, and tests.
  * Added optional race detection, help output, and clear handling for unsupported options.

* **Documentation**
  * Updated contributor and project guidance to recommend the validation command.
  * Clarified toolchain, shell, platform, and dependency prerequisites.

* **Tests**
  * Added validation checks for the command and its documentation and CI integration.
  * Expanded integration test coverage to include the application package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->