### PR TITLE
Stop fish offering filenames for non-path option values

### DIFF
--- a/packaging/completions/netdoc.fish
+++ b/packaging/completions/netdoc.fish
@@ -24,7 +24,7 @@ complete -c netdoc -o two-sided -l two-sided -d 'Localize two saved snapshots, o
 # file completion comes back only while --via is absent.
 complete -c netdoc -n '__fish_seen_argument -o compare -l compare' -F
 complete -c netdoc -n '__fish_seen_argument -o two-sided -l two-sided; and not __fish_seen_argument -o via -l via' -F
-complete -c netdoc -o peer-listen -l peer-listen -r -d 'Listen for an authenticated peer on an exact IP:port (repeatable)'
+complete -c netdoc -o peer-listen -l peer-listen -r -f -d 'Listen for an authenticated peer on an exact IP:port (repeatable)'
 complete -c netdoc -o peer-connect -l peer-connect -d 'Read a temporary pairing string and run a two-ended diagnosis'
 complete -c netdoc -o via -l via -r -f \
     -a '(__fish_print_hostnames)' \
@@ -46,9 +46,9 @@ complete -c netdoc -o no-history -l no-history -d "Don't read or write the saved
 complete -c netdoc -o version -l version -d 'Print version and exit'
 complete -c netdoc -s h -o help -l help -d 'Print usage and exit'
 
-complete -c netdoc -o iface -l iface -r -d 'Bind probes to an interface name or exact local IP' \
+complete -c netdoc -o iface -l iface -r -f -d 'Bind probes to an interface name or exact local IP' \
     -a '(command ls /sys/class/net 2>/dev/null)'
-complete -c netdoc -o public-dns -l public-dns -r -d 'Second-opinion DNS resolver IP, empty to skip (default 8.8.8.8)'
-complete -c netdoc -o keys -l keys -r -d 'Keybinding preset for the TUI (default: default)' \
+complete -c netdoc -o public-dns -l public-dns -r -f -d 'Second-opinion DNS resolver IP, empty to skip (default 8.8.8.8)'
+complete -c netdoc -o keys -l keys -r -f -d 'Keybinding preset for the TUI (default: default)' \
     -a 'default vim'
-complete -c netdoc -o timeout -l timeout -r -d 'Per-check probe timeout (default 4s)'
+complete -c netdoc -o timeout -l timeout -r -f -d 'Per-check probe timeout (default 4s)'

--- a/packaging_test.go
+++ b/packaging_test.go
@@ -517,6 +517,53 @@ func TestShippedSurfacesOfferTheRealProbeIDs(t *testing.T) {
 	}
 }
 
+// The -f at the top of netdoc.fish suppresses file candidates for the whole
+// command, but an option-specific -r can quietly turn them back on for that
+// one option. Every value-taking option whose value is not a path therefore
+// has to repeat -f on its own declaration; the exceptions are the options
+// that genuinely take files, which stay spelled with -F.
+func TestFishKeepsNonPathValuesOffFileCompletion(t *testing.T) {
+	data, err := os.ReadFile("packaging/completions/netdoc.fish")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fish := string(data)
+
+	// -profile, -check, -skip and -via gained -f when their value
+	// completions landed; the rest are the cases that still fell back to
+	// filenames. Kept as one list so a new non-path option has to opt out.
+	noFiles := []string{
+		"profile", "check", "skip", "via",
+		"peer-listen", "iface", "public-dns", "keys", "timeout",
+	}
+	for _, flag := range noFiles {
+		declaration := regexp.MustCompile(`(?m)^complete -c netdoc -o ` + flag + `[^\n]* -f`).FindString(fish)
+		if declaration == "" {
+			t.Errorf("packaging/completions/netdoc.fish: --%s takes a value that is not a path, so its declaration must pass -f", flag)
+			continue
+		}
+		if strings.Contains(declaration, " -F") {
+			t.Errorf("packaging/completions/netdoc.fish: --%s passes -F, which brings file candidates back", flag)
+		}
+	}
+
+	// -save and -support write .ndoc files, and the snapshot arguments of
+	// -compare and offline --two-sided are files too, so those keep -F.
+	for _, flag := range []string{"save", "support"} {
+		if !regexp.MustCompile(`(?m)^complete -c netdoc -o ` + flag + `[^\n]* -F`).MatchString(fish) {
+			t.Errorf("packaging/completions/netdoc.fish: --%s writes a file, so its declaration must keep -F", flag)
+		}
+	}
+	for _, condition := range []string{
+		`-n '__fish_seen_argument -o compare -l compare' -F`,
+		`-n '__fish_seen_argument -o two-sided -l two-sided; and not __fish_seen_argument -o via -l via' -F`,
+	} {
+		if !strings.Contains(fish, condition) {
+			t.Errorf("packaging/completions/netdoc.fish: snapshot file completion must stay gated behind %s", condition)
+		}
+	}
+}
+
 func TestShippedSurfacesOfferTheRealProfiles(t *testing.T) {
 	want := append(profile.Builtins().Names(), "list")
 	completions := []struct {


### PR DESCRIPTION
The fish completion starts with `complete -c netdoc -f` because targets are
hostnames, URLs or IPs, but a few option declarations still used plain `-r`.
Fish then treats those values as file positions and offers whatever is in the
current directory.

Added `-f` to the declarations for --peer-listen, --iface, --public-dns,
--keys and --timeout, same as #58 did for --check and --skip. The options
that genuinely take files (--save, --support, and the snapshot arguments of
--compare / offline --two-sided) still use -F and are unchanged.

Also added a packaging test that keeps the non-path options on -f and the
path options on -F so this does not quietly regress.

Fixes #59


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Fish shell completion so non-file options no longer suggest file paths.
  - Preserved file-path suggestions for options that accept files, along with existing descriptions and value suggestions.

- **Tests**
  - Added coverage to verify correct completion behavior for file and non-file options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->