### PR TITLE
Make TestSSHCommand independent of the home directory

### DIFF
--- a/internal/ui/ssh_test.go
+++ b/internal/ui/ssh_test.go
@@ -73,11 +73,10 @@ func sshResult(t *testing.T, cmd tea.Cmd) sshResolvedMsg {
 }
 
 func TestSSHCommand(t *testing.T) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skip("no home directory")
-	}
-	key := filepath.Join(home, ".ssh", "id_ed25519")
+	// sshCommand treats the key as opaque argv text and never opens it, so a
+	// synthetic nested path stands in for a real one: no home directory to
+	// resolve, nothing to skip, and nothing read from disk.
+	key := "/home/tester/.ssh/id_ed25519"
 
 	tests := []struct {
 		name                          string


### PR DESCRIPTION
## Summary

`TestSSHCommand` built its sample `-i` key path from `os.UserHomeDir()` and skipped the whole table when the host had no resolvable home directory. The production `sshCommand` treats the key as opaque argv text and never opens it, so the test now feeds a synthetic nested `.ssh/id_ed25519` path instead. The chosen-key case still asserts `-i <key> -o IdentitiesOnly=yes` and every other argument-construction case is unchanged. No user-visible behavior changes.

Closes #66

## Validation

- [x] Tests nearest the change pass (`go test ./internal/ui`)
- [x] Normal local validation passed (`go test ./...`, see skipped checks)
- [ ] Full CI gate passed, or the specific checks that did not run are explained below

Commands run on Linux x86_64:

```sh
go test ./internal/ui
go test ./...
```

## Skipped checks

`go test ./...` reports one failure in `internal/diagnostic`, `TestLookupRouteDecisionReadsTheRoutingTableTheKernelUsed` ("table = local (known true), want a known main table"). It reproduces on `main` without this change and depends on this workstation's routing table, so it is pre-existing and unrelated. With `-skip` for that one test, `go test ./internal/diagnostic` passes, and every other package in `go test ./...` passes.

The change is a Go test edit only; no fuzz targets, platform-tagged files, man pages, or `internal/textsafe` code were touched, so their gates do not apply.

## Platforms

Tested on Linux x86_64. The synthetic key path is a plain string compared against the argv `sshCommand` returns, so no platform-specific behavior is exercised and no other OS was tested.

## TUI changes

Not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved SSH command test consistency by using a fixed synthetic key path.
  * Removed dependence on the user’s home directory and related environment-based skipping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->