### PR TITLE
Run the ALL_PROXY test in a proxy-free child process

### DIFF
--- a/internal/diagnostic/checks_extra_test.go
+++ b/internal/diagnostic/checks_extra_test.go
@@ -11,6 +11,8 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"os/exec"
 	"slices"
 	"strings"
 	"sync"
@@ -566,11 +568,34 @@ func TestSOCKS5RejectsInvalidConnectReplyHeader(t *testing.T) {
 
 // Go's own ProxyFromEnvironment ignores ALL_PROXY; netdoc must not, or a box
 // proxied only through ALL_PROXY reads as having no proxy at all.
+//
+// net/http reads HTTP(S)_PROXY and NO_PROXY once per process and caches them,
+// so a machine, container or CI runner that already exports a proxy cannot be
+// undone with t.Setenv here. The assertions therefore run in a child: this
+// same test binary, re-run with every *_PROXY variable stripped, whatever the
+// parent inherited. The marker variable tells the child to run them.
 func TestProxyFromEnvironmentAllProxy(t *testing.T) {
-	req := &http.Request{URL: &url.URL{Scheme: "https", Host: ConnectivityProbeHost}}
-	if u, err := http.ProxyFromEnvironment(req); u != nil || err != nil {
-		t.Skipf("test environment already has HTTP(S)_PROXY set (%v, %v)", u, err)
+	if os.Getenv("NETDOC_PROXY_ENV_HELPER") == "" {
+		args := []string{"-test.run=^TestProxyFromEnvironmentAllProxy$"}
+		// go test -cover exports GOCOVERDIR, but a test binary only writes its
+		// counters there when told to, so the child's coverage of
+		// proxyFromEnvironment lands in the parent's profile.
+		if dir := os.Getenv("GOCOVERDIR"); dir != "" {
+			args = append(args, "-test.gocoverdir="+dir)
+		}
+		// #nosec G204 G702 -- the child is this same test binary, os.Args[0],
+		// re-run with a literal -test.run filter.
+		cmd := exec.Command(os.Args[0], args...)
+		cmd.Env = append(slices.DeleteFunc(os.Environ(), func(kv string) bool {
+			name, _, _ := strings.Cut(kv, "=")
+			return strings.HasSuffix(strings.ToUpper(name), "_PROXY")
+		}), "NETDOC_PROXY_ENV_HELPER=1")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("test rerun without proxy variables: %v\n%s", err, out)
+		}
+		return
 	}
+	req := &http.Request{URL: &url.URL{Scheme: "https", Host: ConnectivityProbeHost}}
 	for _, name := range []string{"ALL_PROXY", "all_proxy"} {
 		t.Run(name, func(t *testing.T) {
 			t.Setenv("ALL_PROXY", "")


### PR DESCRIPTION
## Summary

Fixes #65.

`TestProxyFromEnvironmentAllProxy` skipped whenever the process it ran in already had `HTTPS_PROXY` (or `HTTP_PROXY` for the scheme it asks about) exported, which is exactly the kind of machine where the `ALL_PROXY` fallback matters. `t.Setenv` cannot fix that in place: `net/http` reads `HTTP(S)_PROXY` and `NO_PROXY` once per process and caches them.

The test now re-executes the test binary for itself with every `*_PROXY` variable stripped from the environment (upper and lower case, so `HTTP_PROXY`, `https_proxy`, `ALL_PROXY`, `no_proxy` and friends all go) and a marker variable that tells the child to run the assertions. This is the same re-exec pattern the `GO_HELPER` job tests and the lab isolation test already use. The assertions themselves are unchanged, so `ALL_PROXY`, `all_proxy`, the `NO_PROXY` exemptions and the bare `host:port` default are all still covered, and `probe_proxy.go` is untouched.

When `go test -cover` is in use the child is also handed `-test.gocoverdir`, so `proxyFromEnvironment` and `noProxyBypasses` keep showing up in the coverage profile instead of dropping to zero because only the child calls them.

## Validation

```sh
T='^TestProxyFromEnvironmentAllProxy$'
go test -count=1 -run "$T" -v ./internal/diagnostic
HTTPS_PROXY=http://proxy.example:3128 go test -count=1 -run "$T" -v ./internal/diagnostic
HTTPS_PROXY=http://p:1 https_proxy=http://p:1 HTTP_PROXY=http://p:1 http_proxy=http://p:1 ALL_PROXY=socks5://a:1 all_proxy=socks5://a:1 NO_PROXY='*' no_proxy='*' go test -count=1 -run "$T" -v ./internal/diagnostic
HTTPS_PROXY=http://p:1 go test -count=1 -race -shuffle=on -run "$T" ./internal/diagnostic
HTTPS_PROXY=http://p:1 go test -count=1 -covermode=set -coverprofile=cp.out -run "$T" ./internal/diagnostic
go vet ./internal/diagnostic
GOOS=linux go vet ./internal/diagnostic
GOOS=windows go vet ./internal/diagnostic
go test ./...
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1 run ./internal/diagnostic/...
```

Before the change the second command reports `SKIP: test environment already has HTTP(S)_PROXY set`; after it every subtest runs and passes in all three environments. The coverage profile shows the `proxyFromEnvironment` and `noProxyBypasses` blocks hit through the child. As a check that the child really exercises the fallback, temporarily replacing the two `os.Getenv("ALL_PROXY")`/`os.Getenv("all_proxy")` reads in `probe_proxy.go` with `""` makes the test fail and prints the child's `ALL_PROXY`, `all_proxy`, `NO_PROXY miss still falls back` and `bare host defaults to http` subtest failures.

golangci-lint reports three pre-existing findings in darwin-only files (`route_darwin.go`, `advertised_darwin.go`, `ssid_darwin.go`) that the Linux lint job does not compile; none are in the changed file.

- [x] Tests nearest the change pass
- [x] Normal local validation passed (`go test ./...` plus any checks clearly relevant to the change)
- [ ] Full CI gate passed, or the specific checks that did not run are explained below

## Skipped checks

The `integration`, `acceptance`, `netns_integration`, fuzz, `govulncheck` and `goreleaser check` steps were not run. The change is one test with no network I/O and touches no probe, sanitizer, target parsing, packaging or release configuration.

## Platforms

Tested on macOS (darwin/arm64). Linux and Windows were compile-checked with `go vet` only; the child is the same `os.Args[0]` re-exec that `internal/ui/jobs_test.go` already relies on under CI on all three.

## TUI changes

Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved proxy environment testing to run reliably in a clean subprocess.
  * Preserved coverage for proxy variable handling and bare-host fallback scenarios, even when proxy settings are inherited from the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->