### PR TITLE
Test SSH key discovery against a temporary directory

### DIFF
--- a/internal/ui/ssh.go
+++ b/internal/ui/ssh.go
@@ -145,7 +145,12 @@ func listSSHKeys() []string {
 	if err != nil {
 		return nil
 	}
-	dir := filepath.Join(home, ".ssh")
+	return sshKeysIn(filepath.Join(home, ".ssh"))
+}
+
+// sshKeysIn is the directory scan behind listSSHKeys, with the directory as an
+// argument so tests can point it at a temporary one instead of ~/.ssh.
+func sshKeysIn(dir string) []string {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil

--- a/internal/ui/ssh_test.go
+++ b/internal/ui/ssh_test.go
@@ -873,10 +873,19 @@ func TestSSHKeysIn(t *testing.T) {
 		{name: "public half alone", files: []string{"id_ed25519.pub"}},
 		{name: "private half alone", files: []string{"id_ed25519"}},
 		{name: "directory under the private name", files: []string{"id_rsa.pub"}, dirs: []string{"id_rsa"}},
+		// Trimming ".pub" off a bare ".pub" leaves nothing, and joining
+		// nothing onto the directory names the directory. It is not a
+		// regular file, so it is not offered as a key to ssh -i.
+		{name: "bare .pub file", files: []string{".pub"}},
 		{
+			// The sort has to be the thing that orders these. ReadDir hands
+			// back the full names in order, and "id_ed25519-work.pub" sorts
+			// before "id_ed25519.pub" because '-' is below '.', while the
+			// trimmed key names sort the other way round. Without the sort
+			// this case comes back with the pair swapped.
 			name:  "several keys sort by name",
-			files: []string{"id_rsa", "id_rsa.pub", "id_ed25519", "id_ed25519.pub", "id_ecdsa", "id_ecdsa.pub", "known_hosts", "config"},
-			want:  []string{"id_ecdsa", "id_ed25519", "id_rsa"},
+			files: []string{"id_rsa", "id_rsa.pub", "id_ed25519", "id_ed25519.pub", "id_ed25519-work", "id_ed25519-work.pub", "id_ecdsa", "id_ecdsa.pub", "known_hosts", "config"},
+			want:  []string{"id_ecdsa", "id_ed25519", "id_ed25519-work", "id_rsa"},
 		},
 	}
 	for _, tc := range tests {
@@ -905,6 +914,27 @@ func TestSSHKeysIn(t *testing.T) {
 	t.Run("missing directory", func(t *testing.T) {
 		if got := sshKeysIn(filepath.Join(t.TempDir(), ".ssh")); got != nil {
 			t.Errorf("sshKeysIn = %q, want nil", got)
+		}
+	})
+
+	// The regular-file check runs on what the name resolves to, so a key
+	// symlinked in from a dotfile repository is still a key. Switching that
+	// os.Stat to an os.Lstat would quietly drop it from the form.
+	t.Run("symlinked private half", func(t *testing.T) {
+		dir := t.TempDir()
+		stored := filepath.Join(dir, "stored_key")
+		if err := os.WriteFile(stored, nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		key := filepath.Join(dir, "id_ed25519")
+		if err := os.Symlink(stored, key); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		if err := os.WriteFile(key+".pub", nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if got := sshKeysIn(dir); !slices.Equal(got, []string{key}) {
+			t.Errorf("sshKeysIn = %q, want %q", got, []string{key})
 		}
 	})
 }

--- a/internal/ui/ssh_test.go
+++ b/internal/ui/ssh_test.go
@@ -857,6 +857,58 @@ func TestSSHKeyChooser(t *testing.T) {
 	}
 }
 
+// Key discovery is the .pub file next to a regular private half, nothing
+// else: a lone half of either kind, or a directory wearing the private name,
+// is not a key. Every case runs in its own temporary directory, so no test
+// reads the developer's ~/.ssh or needs a real key.
+func TestSSHKeysIn(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []string // regular files, created empty
+		dirs  []string
+		want  []string // discovered keys, relative to the directory
+	}{
+		{name: "empty directory"},
+		{name: "matching pair", files: []string{"id_ed25519", "id_ed25519.pub"}, want: []string{"id_ed25519"}},
+		{name: "public half alone", files: []string{"id_ed25519.pub"}},
+		{name: "private half alone", files: []string{"id_ed25519"}},
+		{name: "directory under the private name", files: []string{"id_rsa.pub"}, dirs: []string{"id_rsa"}},
+		{
+			name:  "several keys sort by name",
+			files: []string{"id_rsa", "id_rsa.pub", "id_ed25519", "id_ed25519.pub", "id_ecdsa", "id_ecdsa.pub", "known_hosts", "config"},
+			want:  []string{"id_ecdsa", "id_ed25519", "id_rsa"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, d := range tc.dirs {
+				if err := os.Mkdir(filepath.Join(dir, d), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for _, f := range tc.files {
+				if err := os.WriteFile(filepath.Join(dir, f), nil, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			var want []string
+			for _, w := range tc.want {
+				want = append(want, filepath.Join(dir, w))
+			}
+			if got := sshKeysIn(dir); !slices.Equal(got, want) {
+				t.Errorf("sshKeysIn = %q, want %q", got, want)
+			}
+		})
+	}
+
+	t.Run("missing directory", func(t *testing.T) {
+		if got := sshKeysIn(filepath.Join(t.TempDir(), ".ssh")); got != nil {
+			t.Errorf("sshKeysIn = %q, want nil", got)
+		}
+	})
+}
+
 // A password is echoed as dots, never as itself.
 func TestSSHPasswordMasked(t *testing.T) {
 	f := newSSHForm(defaultStyles, mustTarget(t, "example.com"))


### PR DESCRIPTION
## Summary

Fixes #69.

`listSSHKeys()` read `~/.ssh` straight from the user's home directory, so it had no direct unit test: one would have depended on whatever keys the developer or the CI runner happens to keep there.

The scan now lives in `sshKeysIn(dir string) []string`, with the directory as an argument, and `listSSHKeys()` is the one-liner that resolves `~/.ssh` and calls it. The loop body, the regular-file check on the private half and the sort are moved, not changed, so what the SSH form lists is the same as before.

`TestSSHKeysIn` builds each layout in `t.TempDir()` with empty files, so no real key or real home directory is involved:

- `id_ed25519` next to `id_ed25519.pub` is discovered
- `id_ed25519.pub` with no private half is ignored
- `id_ed25519` with no `.pub` is ignored
- a directory named `id_rsa` next to `id_rsa.pub` is not a key
- `id_rsa`, `id_ed25519`, `id_ecdsa` pairs (plus `known_hosts` and `config`) come back as the three keys, sorted
- an empty directory returns nothing
- a missing directory returns nothing

As a check that the test really pins the behavior, temporarily accepting directories in the `IsRegular()` test fails the `directory under the private name` case, and dropping the sibling `os.Stat` fails `public half alone`.

## Validation

```sh
go test -count=1 -run '^TestSSHKeysIn$|^TestSSHKeyChooser$|^TestSSHFormKeys$' -v ./internal/ui
go vet ./...
GOOS=linux go vet ./internal/ui
GOOS=windows go vet ./internal/ui
go test ./...
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1 run ./internal/ui/...
```

- [x] Tests nearest the change pass
- [x] Normal local validation passed (`go test ./...` plus any checks clearly relevant to the change)
- [ ] Full CI gate passed, or the specific checks that did not run are explained below

## Skipped checks

The `integration`, `acceptance`, `netns_integration`, fuzz, `govulncheck` and `goreleaser check` steps were not run. The change is a helper extraction plus one filesystem-only test in `internal/ui`; it touches no probe, sanitizer, target parsing, packaging or release configuration.

## Platforms

Tested on macOS (darwin/arm64). Linux and Windows were compile-checked with `go vet` only; the test uses `os.Mkdir`, `os.WriteFile` and `filepath.Join`, nothing platform-specific.

## TUI changes

Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH key discovery while preserving existing behavior.
  * Correctly handles key pairs, unmatched key files, directories, unrelated files, symlinked private keys, and missing SSH directories.
  * Returns discovered SSH keys in sorted order.

* **Tests**
  * Added coverage for SSH key discovery across valid, incomplete, unrelated, missing, and symlinked entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->