### PR TITLE
ci: lint shipped man pages with mandoc -Tlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,20 @@ jobs:
           for script in packaging/completions/*.bash; do bash -n "$script"; done
           for script in packaging/completions/*.zsh; do zsh -n "$script"; done
           for script in packaging/completions/*.fish; do fish -n "$script"; done
+  
+  manpage-syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install mandoc
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y mandoc
+      - name: Check man page syntax
+        run: |
+          set -euo pipefail
+          mandoc -Tlint packaging/netdoc.1
+          mandoc -Tlint packaging/netdoc-sim.1
 
   test:
     strategy:

--- a/packaging/netdoc-sim.1
+++ b/packaging/netdoc-sim.1
@@ -1,6 +1,7 @@
 .TH NETDOC\-SIM 1 "2026-09-05" "network-doctor" "User Commands"
 .SH NAME
-netdoc\-sim \- build throwaway virtual networks, run netdoc inside them, and score the diagnosis
+netdoc\-sim \- build throwaway virtual networks, run netdoc inside them,
+ and score the diagnosis
 .SH SYNOPSIS
 .B netdoc\-sim
 .I command
@@ -23,7 +24,8 @@ returns. Run
 to see what a run does on this machine and whether it can run at all.
 .PP
 The only backend that builds a live network is Linux namespaces.
-The separate Scenario Lab models observations in memory on Linux, macOS and Windows, without namespaces, network access, or a separate netdoc binary.
+The separate Scenario Lab models observations in memory on Linux, macOS
+ and Windows, without namespaces, network access, or a separate netdoc binary.
 .PP
 Each command parses its own flags. Flags may be given before or after a
 command's positional argument, and each accepts both the single-dash and
@@ -589,7 +591,6 @@ also a failed
 .B gh
 call.
 .SH EXAMPLES
-.PP
 Check whether this host can simulate at all:
 .PP
 .RS 4
@@ -703,8 +704,10 @@ Full documentation starting at
 including scenario authoring, the report schemas, the challenge contract, and
 how the container image is run:
 .UR https://github.com/heymaikol/network-doctor
+network-doctor
 .UE
 .SH BUGS
 Report issues at
 .UR https://github.com/heymaikol/network-doctor/issues
+network-doctor/issues
 .UE

--- a/packaging/netdoc.1
+++ b/packaging/netdoc.1
@@ -1,6 +1,7 @@
 .TH NETDOC 1 "2026-09-02" "network-doctor" "User Commands"
 .SH NAME
-netdoc \- diagnose network connectivity and name the layer where the connection breaks
+netdoc \- diagnose network connectivity and name the layer where the
+ connection breaks
 .SH SYNOPSIS
 .B netdoc
 .RI [ flags ]
@@ -649,7 +650,6 @@ NAT traversal. At least one listener address must be directly reachable. A
 failed reverse connection can be consistent with filtering, routing, or NAT,
 but does not prove which one caused it.
 .SH EXAMPLES
-.PP
 Run the generic local and internet diagnosis:
 .PP
 .RS 4
@@ -812,8 +812,10 @@ and delete the file to clear what is already saved.
 .PP
 Full documentation, including the JSON report schema and the verdict table:
 .UR https://github.com/heymaikol/network-doctor
+network-doctor
 .UE
 .SH BUGS
 Report issues at
 .UR https://github.com/heymaikol/network-doctor/issues
+network-doctor/issues
 .UE


### PR DESCRIPTION
Fix mandoc warnings in netdoc.1 and netdoc-sim.1 (long lines, PP after SH, empty UR blocks) so both pass mandoc -Tlint cleanly, then add a CI job that runs mandoc -Tlint against both shipped man pages on every push and pull request.

Closes #67

## Summary

Adds a CI job that lints both shipped man pages with `mandoc -Tlint`
on every push and pull request, and fixes the existing syntax
warnings in netdoc.1 and netdoc-sim.1 so they pass cleanly.

## Validation

Ran:
- go vet ./...
- CGO_ENABLED=0 go build ./...
- go test ./...
- mandoc -Tlint packaging/netdoc.1
- mandoc -Tlint packaging/netdoc-sim.1

All pass with no warnings and exit code 0.

- [x] Tests nearest the change pass
- [x] Normal local validation passed (`go test ./...` plus any checks clearly relevant to the change)
- [x] Full CI gate passed, or the specific checks that did not run are explained below

## Skipped checks

None. This change only touches CI config and man-page content, so the
full local validation gate above covers it.

## Platforms

Not applicable — this is a CI/tooling change, not platform-specific code.

## TUI changes

Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved formatting and readability across the `netdoc` and `netdoc-sim` manual pages.
  - Added visible repository and issue-tracker URLs to relevant documentation sections.
  - Refined examples and description layout.

- **Tests**
  - Added automated man-page syntax checks to CI for both packaged manuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->