### PR TITLE
Wrap help overlay descriptions to the terminal width

### DIFF
--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -53,6 +54,59 @@ func TestHelpOverlay(t *testing.T) {
 	u, _ = hm.Update(keyMsg("x"))
 	if asModel(t, u).helping {
 		t.Error("any key must close the cheatsheet")
+	}
+}
+
+// TestHelpOverlayFitsNarrowTerminal renders the cheatsheet at the widths the
+// rest of the TUI supports, for every preset. No row may be wider than the
+// terminal: the terminal would hard-wrap it into display rows MaxHeight never
+// counted. A description that wraps must still read against its own key.
+func TestHelpOverlayFitsNarrowTerminal(t *testing.T) {
+	// A continuation row is indented past the key column; an entry row is not.
+	continuation := regexp.MustCompile(`\n {3,}(\S)`)
+	noSpace := func(s string) string { return strings.ReplaceAll(s, " ", "") }
+	for _, preset := range KeyPresets() {
+		km, err := PresetKeymap(preset)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, w := range []int{24, 30, 40, 60, 100} {
+			m := newModel(nil, false)
+			m.keys, m.width, m.height, m.helping = km, w, 24, true
+			if v := m.View(); lipgloss.Height(v) > m.height {
+				t.Errorf("%s %dx%d: view is %d display rows tall:\n%s", preset, w, m.height, lipgloss.Height(v), v)
+			}
+			m.height = 0 // unclipped: every entry must survive wrapping
+			sheet := ansi.Strip(m.helpOverlay())
+			for _, line := range strings.Split(sheet, "\n") {
+				if got := lipgloss.Width(line); got > w {
+					t.Errorf("%s width %d: line is %d wide: %q", preset, w, got, line)
+				}
+			}
+			if !strings.HasPrefix(sheet, "Keys\n") || !strings.Contains(sheet, "\nOutput viewer\n") || !strings.HasSuffix(sheet, "\nany key close") {
+				t.Errorf("%s width %d: headings or close hint lost:\n%s", preset, w, sheet)
+			}
+			// Rejoin each wrapped description and compare it to its metadata
+			// ignoring spaces, since a word too long for the column is split.
+			// Anchoring to the row start pins the description to its key.
+			joined := noSpace(continuation.ReplaceAllString(sheet, "$1"))
+			expect := func(key, desc string) {
+				t.Helper()
+				if !regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(noSpace(key+desc)) + `$`).MatchString(joined) {
+					t.Errorf("%s width %d: %q is not followed by %q:\n%s", preset, w, key, desc, sheet)
+				}
+			}
+			for _, def := range actionDefs {
+				for ctx, help := range def.help {
+					if km.bound(ctx, def.act) && def.act != actSSH {
+						expect(km.label(ctx, def.act), help.details)
+					}
+				}
+			}
+			for _, tool := range m.tools {
+				expect(tool.Key, "run "+tool.Name)
+			}
+		}
 	}
 }
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -1513,10 +1513,17 @@ func (m model) helpOverlay() string {
 			keyWidth = max(keyWidth, lipgloss.Width(m.keys.label(ctx, def.act)))
 		}
 	}
+	// A description wraps in its own column, with a hanging indent, rather than
+	// running past the terminal: the display rows the terminal would hard-wrap
+	// it into are not in MaxHeight's accounting, so they would push the bottom
+	// of the sheet off the screen. ansi.Wrap leaves the text alone when the
+	// width is unknown or narrower than the key column.
+	indent := strings.Repeat(" ", 2+keyWidth+2)
 	row := func(k, desc string) string {
+		desc = ansi.Wrap(m.st.faint.Render(desc), m.width-len(indent), "")
 		return "  " + m.st.key.Render(k) +
 			strings.Repeat(" ", max(keyWidth-lipgloss.Width(k), 0)+2) +
-			m.st.faint.Render(desc) + "\n"
+			strings.ReplaceAll(desc, "\n", "\n"+indent) + "\n"
 	}
 	// Both sections are generated from the same table dispatch indexes.
 	section := func(b *strings.Builder, ctx keyContext) {


### PR DESCRIPTION
## Summary

Fixes #68.

`helpOverlay()` built every row as key, padding, description and never looked at `m.width`, so on a narrow terminal a long description ran past the last column. The terminal then hard-wrapped it into display rows that `MaxHeight` had never counted, and the bottom of the sheet was pushed off the screen. At 30 columns every one of the 36 rows rendered 92 cells wide.

Each description now wraps to the columns left of the key column, with a hanging indent under itself, so a wrapped entry still reads against its key and every display row is in the sheet's own accounting. `ansi.Wrap` is applied to the already-styled text, the same order `m.wrap(m.banner())` uses, and it leaves the text alone when the width is unknown or narrower than the key column. The close hint already wrapped through `helpKeys`, and the `Keys` and `Output viewer` headings are short. The sheet is still generated from `actionDefs` and the active keymap; no bindings, presets or wording changed.

`TestHelpOverlayFitsNarrowTerminal` renders the overlay for both presets at 24, 30, 40, 60 and 100 columns and requires that no row is wider than the terminal, that the headings and close hint survive, and that each description still follows its own key once the continuation rows are rejoined. Against the unchanged `view.go` it reports 150 over-wide rows.

A terminal too short for the wrapped sheet is still clipped by `MaxHeight`, as before; a scrolling cheatsheet is the separate follow-up the issue mentions.

## Validation

```sh
go test -count=1 -run '^TestHelpOverlay|^TestActionMetadataMatchesDispatchAndHelp$' -v ./internal/ui
go test -count=1 ./internal/ui
go vet ./...
GOOS=linux go vet ./internal/ui
GOOS=windows go vet ./internal/ui
go test -count=1 ./...
go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1 run ./internal/ui/...
```

- [x] Tests nearest the change pass
- [x] Normal local validation passed (`go test ./...` plus any checks clearly relevant to the change)
- [ ] Full CI gate passed, or the specific checks that did not run are explained below

## Skipped checks

The `integration`, `acceptance`, `netns_integration`, fuzz, `govulncheck` and `goreleaser check` steps were not run. The change is one rendering function and one test in `internal/ui`; it touches no probe, sanitizer, target parsing, packaging or release configuration.

## Platforms

Tested on macOS (darwin/arm64). Linux and Windows were compile-checked with `go vet` only; the change is string layout with no platform-specific code.

## TUI changes

`vim` preset at 40x24, top of the sheet, ANSI stripped. Before, every row ran to 92 cells and the terminal wrapped them itself:

```
Keys
  ↑/k            previous check, or device/service on the network map
  ↓/j            next check, or device/service on the network map
  gg             first check, or device/service on the network map
  G              last check, or device/service on the network map
  enter          full output; on the network map, open a device then diagnose one of its services
  y              copy selected portal URL, otherwise report
  w              save report
  tab            switch job
  esc            cancel the focused job, or leave an opened device on the network map
```

After:

```
Keys
  ↑/k            previous check, or
                 device/service on the
                 network map
  ↓/j            next check, or
                 device/service on the
                 network map
  gg             first check, or
                 device/service on the
                 network map
  G              last check, or
                 device/service on the
                 network map
  enter          full output; on the
                 network map, open a
                 device then diagnose
                 one of its services
  y              copy selected portal
                 URL, otherwise report
  w              save report
  tab            switch job
  esc            cancel the focused job,
                 or leave an opened
                 device on the network
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Help overlays now wrap keyboard shortcut descriptions within narrow terminal widths.
  - Wrapped lines use consistent indentation, improving readability and preventing text from extending beyond the screen.

- **Tests**
  - Added coverage verifying help overlays fit across multiple narrow terminal sizes, including headings, close hints, key descriptions, and tool entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->