### PR TITLE
Test APK installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,3 +376,23 @@ jobs:
           netdoc --version
           netdoc-sim version
           SMOKE
+
+      # Like the deb and rpm installation checks, exercise the package manager
+      # itself in a clean container. No network ensures the install cannot
+      # silently succeed by fetching an unexpected package dependency.
+      - name: Install the APK in a clean Alpine container
+        run: |
+          set -euo pipefail
+          docker run --rm -i --network none \
+            -v "$PWD/dist:/dist:ro" \
+            alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b \
+            sh -eu <<'SMOKE'
+          test -z "$(command -v netdoc)"
+          test -z "$(command -v netdoc-sim)"
+          apk add --allow-untrusted /dist/*_linux_amd64.apk
+          apk info -e network-doctor
+          test "$(command -v netdoc)" = /usr/bin/netdoc
+          test "$(command -v netdoc-sim)" = /usr/bin/netdoc-sim
+          netdoc --version
+          netdoc-sim version
+          SMOKE


### PR DESCRIPTION
## Summary

- install the GoReleaser APK in a clean Alpine container
- verify `apk` records `network-doctor` as installed
- verify both `netdoc` and `netdoc-sim` are installed at `/usr/bin`
- run both installed executables
- disable container networking so missing package dependencies cannot be fetched

## Validation

- `./scripts/check`
- GoReleaser snapshot build
- clean Alpine installation using the generated amd64 APK
- `apk info -e network-doctor`
- `netdoc --version`
- `netdoc-sim version`

Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated validation for Linux amd64 package installation in a clean, network-isolated Alpine environment.
  - Confirmed the package registers correctly, installs both command-line tools in the expected locations, and that each tool launches successfully.
  - Added checks to ensure the package is self-contained and does not rely on pre-existing installations.
  - Verified installation behavior in a clean environment without network access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->