### PR TITLE
Parse OpenSSH Keyword=value forms in SSH config aliases

### DIFF
--- a/internal/diagnostic/sshconfig.go
+++ b/internal/diagnostic/sshconfig.go
@@ -35,6 +35,32 @@ func SSHHostAliases() map[string]string {
 	return parseSSHAliases(f)
 }
 
+// splitSSHConfigDirective parses one ssh_config line into a keyword and its
+// arguments. OpenSSH accepts "Keyword value", "Keyword=value", and
+// "Keyword = value" (optional whitespace around a single '=').
+func splitSSHConfigDirective(line string) (keyword string, args []string, ok bool) {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", nil, false
+	}
+	i := 0
+	for i < len(line) && line[i] != '=' && line[i] != ' ' && line[i] != '\t' {
+		i++
+	}
+	if i == 0 {
+		return "", nil, false
+	}
+	keyword = line[:i]
+	rest := strings.TrimSpace(line[i:])
+	if strings.HasPrefix(rest, "=") {
+		rest = strings.TrimSpace(rest[1:])
+	}
+	if rest == "" {
+		return keyword, nil, true
+	}
+	return keyword, strings.Fields(rest), true
+}
+
 func parseSSHAliases(r io.Reader) map[string]string {
 	names := make(map[string]string)
 	var aliases []string
@@ -44,24 +70,24 @@ func parseSSHAliases(r io.Reader) map[string]string {
 	// ssh config never comes close, so truncating past it is the intent.
 	b, _ := io.ReadAll(io.LimitReader(r, 1<<20))
 	for _, line := range strings.Split(string(b), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) < 2 || strings.HasPrefix(fields[0], "#") {
+		keyword, args, ok := splitSSHConfigDirective(line)
+		if !ok || len(args) == 0 {
 			continue
 		}
-		switch strings.ToLower(fields[0]) {
+		switch strings.ToLower(keyword) {
 		case "host":
-			aliases = fields[1:]
+			aliases = args
 		case "hostname":
 			// ssh honors only the first HostName per block; so do we,
 			// even when it isn't an IP literal.
 			blockAliases := aliases
 			aliases = nil
-			if net.ParseIP(fields[1]) == nil {
+			if net.ParseIP(args[0]) == nil {
 				continue
 			}
 			for _, a := range blockAliases {
 				if sshAliasRe.MatchString(a) {
-					names[fields[1]] = a
+					names[args[0]] = a
 					break
 				}
 			}

--- a/internal/diagnostic/sshconfig_test.go
+++ b/internal/diagnostic/sshconfig_test.go
@@ -33,14 +33,82 @@ Host v6box
 Host myserver
   HostName myserver.example.com
   HostName 10.0.0.5
+
+Host equals-host
+  HostName=10.0.0.10
+
+Host=equals-host2
+  HostName=10.0.0.11
+
+Host = spaced-equals
+  HostName = 10.0.0.12
+
+HoSt MixedCase
+  hOsTnAmE 10.0.0.13
+
+Host mixed-seps
+  HostName=10.0.0.14
+
+Host=mixed-seps2
+  HostName 10.0.0.15
+
+Host = mixed-seps3
+  HostName=10.0.0.16
 `
 	got := parseSSHAliases(strings.NewReader(config))
 	want := map[string]string{
 		"192.168.1.1": "pihole",
 		"192.168.1.2": "pi-nas",
 		"fd00::7":     "v6box",
+		"10.0.0.10":   "equals-host",
+		"10.0.0.11":   "equals-host2",
+		"10.0.0.12":   "spaced-equals",
+		"10.0.0.13":   "MixedCase",
+		"10.0.0.14":   "mixed-seps",
+		"10.0.0.15":   "mixed-seps2",
+		"10.0.0.16":   "mixed-seps3",
 	}
 	if !maps.Equal(got, want) {
 		t.Fatalf("parseSSHAliases = %v, want %v (non-IP hostnames and pattern aliases skipped)", got, want)
 	}
+}
+
+func TestSplitSSHConfigDirective(t *testing.T) {
+	cases := []struct {
+		line    string
+		keyword string
+		args    []string
+		ok      bool
+	}{
+		{"", "", nil, false},
+		{"# comment", "", nil, false},
+		{"Host pihole", "Host", []string{"pihole"}, true},
+		{"Host=pihole", "Host", []string{"pihole"}, true},
+		{"Host = pihole", "Host", []string{"pihole"}, true},
+		{"HostName 192.168.1.1", "HostName", []string{"192.168.1.1"}, true},
+		{"HostName=192.168.1.1", "HostName", []string{"192.168.1.1"}, true},
+		{"HostName = 192.168.1.1", "HostName", []string{"192.168.1.1"}, true},
+		{"  HostName=192.168.1.1  ", "HostName", []string{"192.168.1.1"}, true},
+		{"Host a b", "Host", []string{"a", "b"}, true},
+		{"Host=a b", "Host", []string{"a", "b"}, true},
+	}
+	for _, tc := range cases {
+		keyword, args, ok := splitSSHConfigDirective(tc.line)
+		if ok != tc.ok || keyword != tc.keyword || !slicesEqual(args, tc.args) {
+			t.Fatalf("splitSSHConfigDirective(%q) = (%q, %v, %v), want (%q, %v, %v)",
+				tc.line, keyword, args, ok, tc.keyword, tc.args, tc.ok)
+		}
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Fixes #89.

## Root cause
`parseSSHAliases` split each line with `strings.Fields` and switched on `fields[0]`. That only handles `Host alias` / `HostName addr`. Valid OpenSSH forms `Host=alias`, `Host = alias`, `HostName=addr`, and `HostName = addr` never matched, so friendly LAN-map labels were dropped.

## Fix
Add `splitSSHConfigDirective` that accepts whitespace or optional whitespace plus a single `=` (same separator rules OpenSSH documents), and use it for `Host` / `HostName` extraction. Existing scope is unchanged: top-level `~/.ssh/config` only, 1 MiB cap, safe alias filter, first-`HostName` semantics, skip pattern aliases.

## Tests
Extended `TestParseSSHAliases` with `=`, spaced `=`, mixed case, and mixed separators; added `TestSplitSSHConfigDirective` for the separator cases from the issue.

## Validation
- `go test` on the package (isolated copy of these files) — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SSH configuration aliases are now recognized when directives use equals signs, spaces around equals signs, or mixed capitalization.
  * Blank lines and comments in SSH configuration files are handled more reliably.
  * Invalid directives containing multiple equals separators are rejected instead of being interpreted incorrectly.
* **Tests**
  * Added coverage for varied SSH directive formatting, separator styles, capitalization, comments, blank lines, and invalid syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->