### PR TITLE
Reject trailing content in captive-portal clean-body checks

### DIFF
--- a/internal/diagnostic/checks.go
+++ b/internal/diagnostic/checks.go
@@ -394,8 +394,8 @@ func publicDNSServer(ip string) string { return net.JoinHostPort(ip, "53") }
 const ncsiProbeHost = "www.msftconnecttest.com"
 
 // ncsiCleanBody is what ncsiProbeHost serves on an unintercepted path. The real
-// payload ends in CRLF; this prefix is all that is read, so an interceptor's
-// page is never searched for it.
+// payload ends in CRLF; bodyMatches accepts this exact string and the same
+// string with a trailing CRLF, and rejects anything beyond those forms.
 const ncsiCleanBody = "Microsoft Connect Test"
 
 // portalEndpoint is one plain-HTTP connectivity observation point. want and
@@ -404,9 +404,11 @@ const ncsiCleanBody = "Microsoft Connect Test"
 type portalEndpoint struct {
 	url  string
 	want int
-	// body is what a clean response begins with, empty where a clean response
-	// carries none. That is the 204's whole contract, and checking a 200 for
-	// its documented payload is what keeps a filter's "OK" page off the clean
+	// body is the documented clean payload, empty where a clean response
+	// carries none. bodyMatches accepts this exact value and, when non-empty,
+	// the same value with a trailing CRLF; arbitrary trailing content is not
+	// clean. That is the 204's whole contract, and checking a 200 for its
+	// documented payload is what keeps a filter's "OK" page off the clean
 	// side of the ledger.
 	body string
 }

--- a/internal/diagnostic/checks_probe_test.go
+++ b/internal/diagnostic/checks_probe_test.go
@@ -2249,10 +2249,46 @@ func TestHTTPSProbeSupportsHTTP2OnlyServer(t *testing.T) {
 	}
 }
 
+// bodyMatches accepts only the documented clean forms: the exact payload and
+// the same payload with a trailing CRLF. Truncation, an altered byte, or any
+// further trailing content is rejected, and the read stays bounded.
+func TestBodyMatches(t *testing.T) {
+	ep := portalEndpoint{body: ncsiCleanBody}
+	longSuffix := ncsiCleanBody + strings.Repeat("x", 4096)
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "exact expected payload", body: ncsiCleanBody, want: true},
+		{name: "expected plus documented CRLF", body: ncsiCleanBody + "\r\n", want: true},
+		{name: "truncated", body: ncsiCleanBody[:len(ncsiCleanBody)-1]},
+		{name: "one incorrect byte", body: "Microsoft Connect Fest"},
+		{name: "expected plus arbitrary HTML", body: ncsiCleanBody + "<html>intercepted</html>"},
+		{name: "expected plus long arbitrary suffix", body: longSuffix},
+		{name: "empty body", body: ""},
+		{name: "CRLF alone", body: "\r\n"},
+		{name: "LF only after payload", body: ncsiCleanBody + "\n"},
+		{name: "CR only after payload", body: ncsiCleanBody + "\r"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ep.bodyMatches(strings.NewReader(c.body))
+			if got != c.want {
+				t.Errorf("bodyMatches(%q) = %v, want %v", c.body, got, c.want)
+			}
+		})
+	}
+	// An endpoint that documents no body stays clean without consuming input.
+	if !((portalEndpoint{}).bodyMatches(strings.NewReader("anything"))) {
+		t.Error("empty documented body should match without reading")
+	}
+}
+
 // The real portalCheckWithDial round trip over in-memory pipes: an endpoint is
-// clean only when it answers exactly what it documents, status and payload
-// both, a redirect is reported rather than chased, and the proxy env never
-// enters the path.
+// clean only when it answers a documented clean form (exact payload or payload
+// plus CRLF), a redirect is reported rather than chased, and the proxy env
+// never enters the path. Prefix-plus-extra bodies are discrepant, not clean.
 func TestPortalCheck(t *testing.T) {
 	// internetProbe only runs the round trips below when the field is wired, so
 	// a nil here disables captive-portal detection with nothing else failing.
@@ -2290,6 +2326,12 @@ func TestPortalCheck(t *testing.T) {
 			// The shape of a filter's "everything is fine" page: a 200 that
 			// says something else entirely.
 			fmt.Fprint(w, "<html>You are connected to GuestWiFi</html>")
+		case "/prefix-html":
+			// Clean prefix followed by an interceptor's page: must not count
+			// as the documented NCSI answer.
+			fmt.Fprint(w, ncsiCleanBody+"<html>intercepted page...</html>")
+		case "/prefix-long":
+			fmt.Fprint(w, ncsiCleanBody+strings.Repeat("x", 4096))
 		case "/redirect":
 			http.Redirect(w, r, "/signin", http.StatusFound)
 		case "/unsafe":
@@ -2327,6 +2369,10 @@ func TestPortalCheck(t *testing.T) {
 		// clean NCSI answer, which is how a filter's own page gets counted.
 		{name: "200 with the wrong payload", ep: withBody("/wrongbody"), wantCode: http.StatusOK},
 		{name: "200 with a short payload", ep: withBody("/truncated"), wantCode: http.StatusOK},
+		// Prefix match alone is not enough: trailing HTML or a long suffix
+		// after the clean payload is discrepant, not clean.
+		{name: "200 with clean prefix plus HTML", ep: withBody("/prefix-html"), wantCode: http.StatusOK},
+		{name: "200 with clean prefix plus long suffix", ep: withBody("/prefix-long"), wantCode: http.StatusOK},
 		{name: "204 where a payload was documented", ep: withBody("/generate_204"), wantCode: http.StatusNoContent},
 		{name: "payload where a 204 was documented", ep: noBody("/connecttest.txt"), wantCode: http.StatusOK},
 		{name: "intercepted", ep: noBody("/redirect"), wantCode: http.StatusFound, wantRedirect: base + "/signin"},

--- a/internal/diagnostic/probe_connectivity.go
+++ b/internal/diagnostic/probe_connectivity.go
@@ -71,16 +71,30 @@ func portalCheckWithDial(ctx context.Context, ep portalEndpoint, dial func(conte
 	return o, nil
 }
 
-// bodyMatches reads exactly as many bytes as the documented payload and not one
-// more, so an endpoint that promises a body has to send that body and an
-// intercepting page cannot be scanned for it.
+// bodyMatches reports whether body is a documented clean payload for this
+// endpoint. The accepted forms are the exact body and, when a body is
+// documented, that same body with a trailing CRLF (what the real NCSI endpoint
+// serves). Truncation, an altered byte, or any further trailing content is
+// rejected. The read stops after len(body)+3 bytes so an interceptor's page is
+// never scanned unboundedly.
 func (ep portalEndpoint) bodyMatches(body io.Reader) bool {
 	if ep.body == "" {
 		return true
 	}
-	buf := make([]byte, len(ep.body))
-	_, err := io.ReadFull(body, buf)
-	return err == nil && string(buf) == ep.body
+	// Exact payload, or exact payload + CRLF. One extra byte past those forms
+	// detects trailing content without reading the rest of the response.
+	limit := len(ep.body) + len("\r\n") + 1
+	buf := make([]byte, limit)
+	n, err := io.ReadFull(body, buf)
+	if err == nil {
+		// Full buffer: more than body+CRLF.
+		return false
+	}
+	if err != io.ErrUnexpectedEOF && err != io.EOF {
+		return false
+	}
+	got := string(buf[:n])
+	return got == ep.body || got == ep.body+"\r\n"
 }
 
 // portalNote states what the discrepant endpoints answered, for a detail


### PR DESCRIPTION
## Summary
`portalEndpoint.bodyMatches` only read a prefix-length slice, so `Microsoft Connect Test` plus arbitrary trailing HTML still counted as clean. It now accepts only the documented clean forms (exact payload, or exact payload + CRLF) via a bounded read (`len(body)+3`), and rejects truncation, altered bytes, and trailing content.

## Test plan
- [x] `go test ./internal/diagnostic -run 'TestBodyMatches|TestPortalCheck$'`
- [x] Unit cases: exact, +CRLF, truncated, wrong byte, +HTML, +long suffix
- [x] `TestPortalCheck` observation path treats prefix-plus-extra as discrepant (not clean)
- Note: full `./scripts/check` hits a pre-existing env-specific `TestLookupRouteDecisionReadsTheRoutingTableTheKernelUsed` failure on this host (also fails on clean `main`); gofmt/vet/build and portal tests pass.

Fixes #98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved network connectivity diagnostics to correctly recognize valid portal responses with an optional trailing line break.
  - Responses that are truncated, altered, or contain unexpected additional content are now correctly identified as non-clean.

- **Tests**
  - Added coverage for valid, invalid, and extended response bodies to improve detection reliability.

- **Documentation**
  - Clarified the documented response formats used by connectivity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->