### PR TITLE
Compare recorded cleartext CONNECT observations

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2165,6 +2165,70 @@ func TestRunCompareIdenticalSnapshotsExitZero(t *testing.T) {
 	}
 }
 
+func TestRunCompareConnectCleartext(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		before, after bool
+		wantCode      int
+		wantText      string
+	}{
+		{"recorded", false, true, 1, "plaintext HTTP CONNECT observation changed from not recorded to recorded"},
+		{"not recorded", true, false, 1, "plaintext HTTP CONNECT observation changed from recorded to not recorded"},
+		{"both recorded", true, true, 0, "No meaningful differences."},
+		{"neither recorded", false, false, 0, "No meaningful differences."},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			before, after := comparableSnapshot(), comparableSnapshot()
+			before.Checks = append(before.Checks, snapshot.Check{
+				ID: "proxy_connect", Status: snapshot.StatusPass, Ran: true,
+				Observed: &snapshot.Observed{ConnectCleartext: tt.before},
+			})
+			after.Checks = append(after.Checks, snapshot.Check{
+				ID: "proxy_connect", Status: snapshot.StatusPass, Ran: true,
+				Observed: &snapshot.Observed{ConnectCleartext: tt.after},
+			})
+			beforePath := writeSnapshotFile(t, dir, "before", before)
+			afterPath := writeSnapshotFile(t, dir, "after", after)
+			for _, format := range []string{"text", "json"} {
+				t.Run(format, func(t *testing.T) {
+					args := []string{"--compare"}
+					if format == "json" {
+						args = append(args, "--json")
+					}
+					args = append(args, beforePath, afterPath)
+					var stdout, stderr bytes.Buffer
+					if got := run(args, &stdout, &stderr); got != tt.wantCode {
+						t.Fatalf("exit = %d, want %d; stderr: %s", got, tt.wantCode, stderr.String())
+					}
+					if stderr.Len() != 0 {
+						t.Errorf("stderr = %q, want empty", stderr.String())
+					}
+					if format == "text" {
+						if !strings.Contains(stdout.String(), tt.wantText) {
+							t.Errorf("output does not contain %q:\n%s", tt.wantText, stdout.String())
+						}
+						return
+					}
+					var got compare.Comparison
+					if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+						t.Fatalf("decode comparison: %v", err)
+					}
+					if tt.wantCode == 0 {
+						if !got.Same() {
+							t.Errorf("equal observations produced changes: %+v", got.Changes)
+						}
+						return
+					}
+					if len(got.Changes) != 1 || got.Changes[0].Path != "checks.proxy_connect.observed.connect_cleartext" {
+						t.Fatalf("changes = %+v, want only connect_cleartext", got.Changes)
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestRunCompareJSON(t *testing.T) {
 	dir := t.TempDir()
 	before := comparableSnapshot()

--- a/internal/compare/compare.go
+++ b/internal/compare/compare.go
@@ -598,6 +598,10 @@ func diffObserved(d *diff, id string, before, after snapshot.Observed) {
 		portalWord(before.Portal), portalWord(after.Portal))
 	d.field(SectionCheck, id, path+"portal.redirect_url", id+" captive portal sign-in URL",
 		portalURL(before.Portal), portalURL(after.Portal))
+	// This is a positive-only observation: false does not establish that the
+	// client-to-proxy hop used TLS or that no cleartext hostname was sent.
+	d.field(SectionCheck, id, path+"connect_cleartext", id+" plaintext HTTP CONNECT observation",
+		recordedWord(before.ConnectCleartext), recordedWord(after.ConnectCleartext))
 	diffAttempts(d, id, path, before.Attempts, after.Attempts)
 	diffRoutes(d, id, path, before.Routes, after.Routes)
 	// A clock reading is a measurement, and its milliseconds drift between two
@@ -608,6 +612,13 @@ func diffObserved(d *diff, id string, before, after snapshot.Observed) {
 		clockOffset(before.ClockOffsetMs), clockOffset(after.ClockOffsetMs))
 	d.field(SectionCheck, id, path+"timeout", id+" failed by timing out",
 		yesNo(before.Timeout), yesNo(after.Timeout))
+}
+
+func recordedWord(recorded bool) string {
+	if recorded {
+		return "recorded"
+	}
+	return "not recorded"
 }
 
 func familiesOf(o snapshot.Observed) snapshot.Families {

--- a/internal/compare/compare_test.go
+++ b/internal/compare/compare_test.go
@@ -90,6 +90,51 @@ func TestIdenticalSnapshotsHaveNoDifferences(t *testing.T) {
 	}
 }
 
+func TestConnectCleartextObservation(t *testing.T) {
+	states := []struct {
+		name     string
+		observed *snapshot.Observed
+		recorded bool
+		word     string
+	}{
+		{"absent", nil, false, "not recorded"},
+		{"false", &snapshot.Observed{}, false, "not recorded"},
+		{"true", &snapshot.Observed{ConnectCleartext: true}, true, "recorded"},
+	}
+	const path = "checks.proxy_connect.observed.connect_cleartext"
+	for _, before := range states {
+		for _, after := range states {
+			t.Run(before.name+" to "+after.name, func(t *testing.T) {
+				b, a := fixture(t), fixture(t)
+				b.Checks = []snapshot.Check{{ID: "proxy_connect", Status: snapshot.StatusPass, Ran: true, Observed: before.observed}}
+				a.Checks = []snapshot.Check{{ID: "proxy_connect", Status: snapshot.StatusPass, Ran: true, Observed: after.observed}}
+				c := Snapshots(b, a)
+				wantDiff := before.recorded != after.recorded
+				if c.Same() == wantDiff {
+					t.Errorf("Same() = %v, want %v", c.Same(), !wantDiff)
+				}
+				if len(c.Checks) != 1 {
+					t.Fatalf("check rows = %v, want only proxy_connect", c.Checks)
+				}
+				row := c.Checks[0]
+				if row.ID != "proxy_connect" || row.Differs != wantDiff || row.Kind != KindUnchanged || row.Direction != "" {
+					t.Errorf("row = %+v, want unchanged status and Differs = %v", row, wantDiff)
+				}
+				if !wantDiff {
+					return
+				}
+				if got := paths(c); !slices.Equal(got, []string{path}) {
+					t.Fatalf("changes = %v, want only %s", got, path)
+				}
+				change := changeAt(t, c, path)
+				if change.Before != before.word || change.After != after.word || change.Kind != KindChanged || change.Direction != "" {
+					t.Errorf("change = %+v, want %q to %q without a health direction", change, before.word, after.word)
+				}
+			})
+		}
+	}
+}
+
 func TestSanitizedSupportSnapshotComparesNormally(t *testing.T) {
 	s := fixture(t)
 	s.Options.Source = &snapshot.Source{Interface: "private-wg", IPv4: "10.20.30.40"}


### PR DESCRIPTION
"--compare" currently treats snapshots that differ only in "Observed.ConnectCleartext" as equal and exits 0. This hides a change in recorded plaintext HTTP CONNECT exposure.

This PR includes the observation in "diffObserved", using the stable path "checks.<id>.observed.connect_cleartext". Values are described as "recorded" and "not recorded", so an absent/false value does not imply TLS protection or prove that no cleartext hostname was sent. Connectivity status and health direction remain unchanged.

Regression tests cover absent, false, and true observations; "Comparison.Same()" and "CheckRow.Differs"; and text/JSON CLI output and exit codes in both directions, including equal values.

Validation on Linux with Go 1.27.1:

- Reproduced the bug on the unmodified baseline: differing observations returned "Same() == true" and CLI exit 0.
- The new comparison and CLI regression tests pass with the fix. The full "internal/compare" suite passes.
- "./scripts/check": formatting, vet, the CGO-disabled build, and macOS/Windows/FreeBSD cross-compiles pass. The test stage has five host-dependent failures involving netlink access and process identity; all five reproduce on the unmodified baseline. The complete check therefore does not pass in this environment.
- Native macOS and Windows runtime tests were not run.

Fixes #92.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Comparison results now detect changes to whether the `proxy_connect` check recorded cleartext connectivity.
  - Text output describes changes as “recorded” or “not recorded.”
  - JSON output includes the change at `checks.proxy_connect.observed.connect_cleartext`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->