### PR TITLE
Bound offline .ndoc reads before JSON decoding

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2033,16 +2033,15 @@ func TestReadSnapshotPairAcceptsGeneratedWatchIncidentArtifact(t *testing.T) {
 	start := time.Date(2026, 8, 25, 12, 0, 0, 0, time.FixedZone("test", -5*60*60))
 
 	failing := func(at time.Time) snapshot.Snapshot {
-		return snapshot.Snapshot{
-			Schema:    snapshot.Schema,
-			CreatedAt: at.UTC().Format(time.RFC3339),
-			Target:    &snapshot.Target{Raw: "example.com", Host: "example.com", Port: 443, Protocol: "tls+http"},
-			Checks: []snapshot.Check{{
-				ID: "target_tcp", Name: "Target TCP", Status: snapshot.StatusFail, Ran: true, DurationMs: 1,
-			}},
-			Diagnosis: snapshot.Diagnosis{Verdict: "network", Summary: "failing", FailedStage: "target_tcp"},
-		}
+	s := comparableSnapshot()
+	s.CreatedAt = at.UTC().Format(time.RFC3339)
+	s.Checks = []snapshot.Check{
+		{ID: "target_tcp", Name: "Target TCP", Status: snapshot.StatusFail, Ran: true, DurationMs: 1},
 	}
+	s.Diagnosis = snapshot.Diagnosis{Verdict: "network", Summary: "failing", FailedStage: "target_tcp"}
+	s.OK = false
+	return s
+}
 
 	var timeline incident.Timeline
 	timeline.Observe(start, failing(start))

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/heymaikol/network-doctor/internal/compare"
 	"github.com/heymaikol/network-doctor/internal/diagnostic"
+	"github.com/heymaikol/network-doctor/internal/incident"
 	"github.com/heymaikol/network-doctor/internal/peer"
 	"github.com/heymaikol/network-doctor/internal/report"
 	"github.com/heymaikol/network-doctor/internal/snapshot"
@@ -2010,19 +2011,57 @@ func TestReadSnapshotPairEnforcesMaxArtifactSize(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			var stdout, stderr bytes.Buffer
-			// --compare needs two paths; pair each file with itself so we
-			// only exercise the read/bound path, not comparison semantics.
-			got := run([]string{"--compare", c.path, c.path}, &stdout, &stderr)
+			for _, mode := range []string{"--compare", "--two-sided"} {
+				var stdout, stderr bytes.Buffer
+				got := run([]string{mode, c.path, c.path}, &stdout, &stderr)
 
-			gotSizeErr := strings.Contains(stderr.String(), "exceeds maximum artifact size")
-			if gotSizeErr != c.wantSizeErr {
-				t.Fatalf("size-limit error = %v, want %v; exit = %d, stderr: %s", gotSizeErr, c.wantSizeErr, got, stderr.String())
-			}
-			if c.wantSizeErr && got != 2 {
-				t.Errorf("exit = %d, want 2 for an unusable artifact; stderr: %s", got, stderr.String())
+				gotSizeErr := strings.Contains(stderr.String(), "exceeds maximum artifact size")
+				if gotSizeErr != c.wantSizeErr {
+					t.Fatalf("%s: size-limit error = %v, want %v; exit = %d, stderr: %s", mode, gotSizeErr, c.wantSizeErr, got, stderr.String())
+				}
+				if c.wantSizeErr && got != 2 {
+					t.Errorf("%s: exit = %d, want 2 for an unusable artifact; stderr: %s", mode, got, stderr.String())
+				}
 			}
 		})
+	}
+}
+
+// A snapshot produced by the real watch-incident machinery, not a
+// hand-built one, must remain readable by the bounded offline reader.
+func TestReadSnapshotPairAcceptsGeneratedWatchIncidentArtifact(t *testing.T) {
+	start := time.Date(2026, 8, 25, 12, 0, 0, 0, time.FixedZone("test", -5*60*60))
+
+	failing := func(at time.Time) snapshot.Snapshot {
+		return snapshot.Snapshot{
+			Schema:    snapshot.Schema,
+			CreatedAt: at.UTC().Format(time.RFC3339),
+			Target:    &snapshot.Target{Raw: "example.com", Host: "example.com", Port: 443, Protocol: "tls+http"},
+			Checks: []snapshot.Check{{
+				ID: "target_tcp", Name: "Target TCP", Status: snapshot.StatusFail, Ran: true, DurationMs: 1,
+			}},
+			Diagnosis: snapshot.Diagnosis{Verdict: "network", Summary: "failing", FailedStage: "target_tcp"},
+		}
+	}
+
+	var timeline incident.Timeline
+	timeline.Observe(start, failing(start))
+	timeline.Observe(start.Add(5*time.Second), failing(start.Add(5*time.Second)))
+	active, ok := timeline.Active()
+	if !ok {
+		t.Fatal("expected an active incident")
+	}
+	artifact := active.Artifact()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "watch-incident"+snapshot.Extension)
+	if err := snapshot.WriteFile(path, artifact); err != nil {
+		t.Fatalf("write generated watch-incident artifact: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if got := run([]string{"--compare", path, path}, &stdout, &stderr); got != 0 {
+		t.Fatalf("exit = %d, want 0 for a real watch-incident artifact compared with itself; stderr: %s", got, stderr.String())
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2039,6 +2039,7 @@ func writeSizedFile(t *testing.T, path string, n int) {
 // real bytes on disk, so the test itself stays fast and light.
 func writeSparseFile(t *testing.T, path string, n int) {
 	t.Helper()
+	// #nosec G304 -- path is built from t.TempDir() in this test, not user input.
 	f, err := os.Create(path)
 	if err != nil {
 		t.Fatalf("create %s: %v", path, err)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1998,14 +1998,14 @@ func TestReadSnapshotPairEnforcesMaxArtifactSize(t *testing.T) {
 	sparsePath := filepath.Join(dir, "sparse"+snapshot.Extension)
 	writeSparseFile(t, sparsePath, snapshot.MaxArtifactBytes*4)
 
-		cases := []struct {
+	cases := []struct {
 		name         string
 		path         string
 		wantSizeErr  bool
 		wantExitCode int
 	}{
 		{"normal snapshot", normalPath, false, 0},
-	    {"at accepted boundary", atBoundaryPath, false, 2},
+		{"at accepted boundary", atBoundaryPath, false, 2},
 		{"exceeds boundary", overBoundaryPath, true, 2},
 		{"oversized sparse file", sparsePath, true, 2},
 	}
@@ -2016,7 +2016,7 @@ func TestReadSnapshotPairEnforcesMaxArtifactSize(t *testing.T) {
 				var stdout, stderr bytes.Buffer
 				got := run([]string{mode, c.path, c.path}, &stdout, &stderr)
 
-						gotSizeErr := strings.Contains(stderr.String(), "exceeds maximum artifact size")
+				gotSizeErr := strings.Contains(stderr.String(), "exceeds maximum artifact size")
 				if gotSizeErr != c.wantSizeErr {
 					t.Fatalf("%s: size-limit error = %v, want %v; exit = %d, stderr: %s", mode, gotSizeErr, c.wantSizeErr, got, stderr.String())
 				}
@@ -2037,15 +2037,15 @@ func TestReadSnapshotPairAcceptsGeneratedWatchIncidentArtifact(t *testing.T) {
 	start := time.Date(2026, 8, 25, 12, 0, 0, 0, time.FixedZone("test", -5*60*60))
 
 	failing := func(at time.Time) snapshot.Snapshot {
-	s := comparableSnapshot()
-	s.CreatedAt = at.UTC().Format(time.RFC3339)
-	s.Checks = []snapshot.Check{
-		{ID: "target_tcp", Name: "Target TCP", Status: snapshot.StatusFail, Ran: true, DurationMs: 1},
+		s := comparableSnapshot()
+		s.CreatedAt = at.UTC().Format(time.RFC3339)
+		s.Checks = []snapshot.Check{
+			{ID: "target_tcp", Name: "Target TCP", Status: snapshot.StatusFail, Ran: true, DurationMs: 1},
+		}
+		s.Diagnosis = snapshot.Diagnosis{Verdict: "network", Summary: "failing", FailedStage: "target_tcp"}
+		s.OK = false
+		return s
 	}
-	s.Diagnosis = snapshot.Diagnosis{Verdict: "network", Summary: "failing", FailedStage: "target_tcp"}
-	s.OK = false
-	return s
-}
 
 	var timeline incident.Timeline
 	timeline.Observe(start, failing(start))

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1998,15 +1998,16 @@ func TestReadSnapshotPairEnforcesMaxArtifactSize(t *testing.T) {
 	sparsePath := filepath.Join(dir, "sparse"+snapshot.Extension)
 	writeSparseFile(t, sparsePath, snapshot.MaxArtifactBytes*4)
 
-	cases := []struct {
-		name        string
-		path        string
-		wantSizeErr bool
+		cases := []struct {
+		name         string
+		path         string
+		wantSizeErr  bool
+		wantExitCode int
 	}{
-		{"normal snapshot", normalPath, false},
-		{"at accepted boundary", atBoundaryPath, false},
-		{"exceeds boundary", overBoundaryPath, true},
-		{"oversized sparse file", sparsePath, true},
+		{"normal snapshot", normalPath, false, 0},
+	    {"at accepted boundary", atBoundaryPath, false, 2},
+		{"exceeds boundary", overBoundaryPath, true, 2},
+		{"oversized sparse file", sparsePath, true, 2},
 	}
 
 	for _, c := range cases {
@@ -2015,12 +2016,15 @@ func TestReadSnapshotPairEnforcesMaxArtifactSize(t *testing.T) {
 				var stdout, stderr bytes.Buffer
 				got := run([]string{mode, c.path, c.path}, &stdout, &stderr)
 
-				gotSizeErr := strings.Contains(stderr.String(), "exceeds maximum artifact size")
+						gotSizeErr := strings.Contains(stderr.String(), "exceeds maximum artifact size")
 				if gotSizeErr != c.wantSizeErr {
 					t.Fatalf("%s: size-limit error = %v, want %v; exit = %d, stderr: %s", mode, gotSizeErr, c.wantSizeErr, got, stderr.String())
 				}
-				if c.wantSizeErr && got != 2 {
-					t.Errorf("%s: exit = %d, want 2 for an unusable artifact; stderr: %s", mode, got, stderr.String())
+				if got != c.wantExitCode {
+					t.Errorf("%s: exit = %d, want %d for %s; stderr: %s", mode, got, c.wantExitCode, c.name, stderr.String())
+				}
+				if c.wantSizeErr && !strings.Contains(stderr.String(), c.path) {
+					t.Errorf("%s: stderr missing artifact path %q; stderr: %s", mode, c.path, stderr.String())
 				}
 			}
 		})

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1974,6 +1974,81 @@ func TestRunTwoSidedExitsZeroWhenNothingFailed(t *testing.T) {
 	}
 }
 
+// Offline .ndoc reads must stay bounded before JSON decoding: a corrupt or
+// deliberately oversized artifact should not be fully read into memory just
+// because it has a .ndoc path.
+func TestReadSnapshotPairEnforcesMaxArtifactSize(t *testing.T) {
+	dir := t.TempDir()
+
+	// A normal, legitimately small snapshot must still work exactly as before.
+	normalPath := writeSnapshotFile(t, dir, "normal", comparableSnapshot())
+
+	// A file sitting exactly at the accepted boundary. It won't decode as a
+	// valid snapshot, but it must NOT be rejected for size.
+	atBoundaryPath := filepath.Join(dir, "boundary"+snapshot.Extension)
+	writeSizedFile(t, atBoundaryPath, snapshot.MaxArtifactBytes)
+
+	// One byte over the boundary: must be rejected for size, before decode.
+	overBoundaryPath := filepath.Join(dir, "over"+snapshot.Extension)
+	writeSizedFile(t, overBoundaryPath, snapshot.MaxArtifactBytes+1)
+
+	// A sparse file far larger than the boundary, to prove the read itself
+	// stays bounded rather than relying on Stat().Size() alone.
+	sparsePath := filepath.Join(dir, "sparse"+snapshot.Extension)
+	writeSparseFile(t, sparsePath, snapshot.MaxArtifactBytes*4)
+
+	cases := []struct {
+		name        string
+		path        string
+		wantSizeErr bool
+	}{
+		{"normal snapshot", normalPath, false},
+		{"at accepted boundary", atBoundaryPath, false},
+		{"exceeds boundary", overBoundaryPath, true},
+		{"oversized sparse file", sparsePath, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			// --compare needs two paths; pair each file with itself so we
+			// only exercise the read/bound path, not comparison semantics.
+			got := run([]string{"--compare", c.path, c.path}, &stdout, &stderr)
+
+			gotSizeErr := strings.Contains(stderr.String(), "exceeds maximum artifact size")
+			if gotSizeErr != c.wantSizeErr {
+				t.Fatalf("size-limit error = %v, want %v; exit = %d, stderr: %s", gotSizeErr, c.wantSizeErr, got, stderr.String())
+			}
+			if c.wantSizeErr && got != 2 {
+				t.Errorf("exit = %d, want 2 for an unusable artifact; stderr: %s", got, stderr.String())
+			}
+		})
+	}
+}
+
+// writeSizedFile writes exactly n bytes of filler content to path.
+func writeSizedFile(t *testing.T, path string, n int) {
+	t.Helper()
+	data := bytes.Repeat([]byte("x"), n)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// writeSparseFile creates a file that reports size n without allocating n
+// real bytes on disk, so the test itself stays fast and light.
+func writeSparseFile(t *testing.T, path string, n int) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", path, err)
+	}
+	defer f.Close()
+	if err := f.Truncate(int64(n)); err != nil {
+		t.Fatalf("truncate %s: %v", path, err)
+	}
+}
+
 func TestRunTwoSidedJSON(t *testing.T) {
 	dir := t.TempDir()
 	here := comparableSnapshot()

--- a/internal/app/artifact_read.go
+++ b/internal/app/artifact_read.go
@@ -65,7 +65,7 @@ func readSnapshotPair(mode string, paths []string, usage string, stderr io.Write
 			return snapshots, false
 		}
 		data, err := io.ReadAll(io.LimitReader(f, snapshot.MaxArtifactBytes+1))
-		f.Close()
+		_ = f.Close() // #nosec G104 -- read-only handle; a close error here cannot affect data already read
 		if err != nil {
 			fmt.Fprintf(stderr, "netdoc: -%s: %s\n", mode, textsafe.Clean(err.Error()))
 			return snapshots, false

--- a/internal/app/artifact_read.go
+++ b/internal/app/artifact_read.go
@@ -59,9 +59,19 @@ func readSnapshotPair(mode string, paths []string, usage string, stderr io.Write
 	for i, path := range paths {
 		// #nosec G304 -- the path is the user's own argument, and reading the
 		// file they named is the whole command.
-		data, err := os.ReadFile(path)
+		f, err := os.Open(path)
 		if err != nil {
 			fmt.Fprintf(stderr, "netdoc: -%s: %s\n", mode, textsafe.Clean(err.Error()))
+			return snapshots, false
+		}
+		data, err := io.ReadAll(io.LimitReader(f, snapshot.MaxArtifactBytes+1))
+		f.Close()
+		if err != nil {
+			fmt.Fprintf(stderr, "netdoc: -%s: %s\n", mode, textsafe.Clean(err.Error()))
+			return snapshots, false
+		}
+		if len(data) > snapshot.MaxArtifactBytes {
+			fmt.Fprintf(stderr, "netdoc: -%s: %s: exceeds maximum artifact size of %d bytes\n", mode, textsafe.Clean(path), snapshot.MaxArtifactBytes)
 			return snapshots, false
 		}
 		// One decoder for both files, the same one that reads a snapshot

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -630,7 +630,7 @@ func Encode(s Snapshot) ([]byte, error) {
 	if err := enc.Encode(s); err != nil {
 		return nil, err
 	}
-		return checkArtifactSize(buf.Bytes())
+	return checkArtifactSize(buf.Bytes())
 }
 
 // EncodeProfile renders a multi-run profile artifact without changing the
@@ -649,7 +649,7 @@ func EncodeProfile(profile ProfileSnapshot) ([]byte, error) {
 	if err := enc.Encode(profile); err != nil {
 		return nil, err
 	}
-		return checkArtifactSize(buf.Bytes())
+	return checkArtifactSize(buf.Bytes())
 }
 
 func validProfileName(name string) bool {

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -44,6 +44,15 @@ const ProfileSchema = "netdoc.profile.v1"
 // schema string in the file is the identity, not the name it was saved under.
 const Extension = ".ndoc"
 
+// MaxArtifactBytes bounds an ordinary offline .ndoc read. The format has no
+// declared maximum row or dependency count, so this is deliberately generous
+// rather than derived from a field-level limit: it exists to stop a corrupt
+// or deliberately oversized file from being fully read into memory before
+// validation, not to constrain any legitimate snapshot. Set above
+// remote.MaxResponseBytes (8 MiB) since one snapshot can bundle more data
+// than a single remote response.
+const MaxArtifactBytes = 16 << 20 // 16 MiB
+
 // The outcomes a check row can carry. They are written down here rather than
 // borrowed from the runtime status type, because the vocabulary of the file is
 // part of the file format: a reader decides what a row means by comparing

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -611,6 +611,12 @@ type CounterfactualAlternative struct {
 // is the zero value of a Go string and not an outcome, and a run holding a
 // check that never reported is not a clean one, so neither can be published:
 // the absence of evidence never leaves here looking like evidence.
+func checkArtifactSize(buf []byte) ([]byte, error) {
+	if len(buf) > MaxArtifactBytes {
+		return nil, fmt.Errorf("snapshot exceeds maximum artifact size of %d bytes; the format has no smaller declared representation", MaxArtifactBytes)
+	}
+	return buf, nil
+}
 func Encode(s Snapshot) ([]byte, error) {
 	s = stamped(s)
 	if err := validate(s); err != nil {
@@ -624,7 +630,7 @@ func Encode(s Snapshot) ([]byte, error) {
 	if err := enc.Encode(s); err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
+		return checkArtifactSize(buf.Bytes())
 }
 
 // EncodeProfile renders a multi-run profile artifact without changing the
@@ -643,10 +649,7 @@ func EncodeProfile(profile ProfileSnapshot) ([]byte, error) {
 	if err := enc.Encode(profile); err != nil {
 		return nil, err
 	}
-	if buf.Len() > MaxArtifactBytes {
-		return nil, fmt.Errorf("snapshot exceeds maximum artifact size of %d bytes; the format has no smaller declared limit, so this reflects the actual encoded size", MaxArtifactBytes)
-	}
-	return buf.Bytes(), nil
+		return checkArtifactSize(buf.Bytes())
 }
 
 func validProfileName(name string) bool {

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -643,6 +643,9 @@ func EncodeProfile(profile ProfileSnapshot) ([]byte, error) {
 	if err := enc.Encode(profile); err != nil {
 		return nil, err
 	}
+	if buf.Len() > MaxArtifactBytes {
+		return nil, fmt.Errorf("snapshot exceeds maximum artifact size of %d bytes; the format has no smaller declared limit, so this reflects the actual encoded size", MaxArtifactBytes)
+	}
 	return buf.Bytes(), nil
 }
 


### PR DESCRIPTION
Introduce MaxArtifactBytes to cap how much of a .ndoc file readSnapshotPair reads before snapshot.Decode runs, so a corrupt or deliberately oversized artifact cannot consume unbounded memory just because it has a .ndoc path. Matches the io.LimitReader pattern already used for the remote protocol's byte cap.

Fixes #88

## Summary

Offline `--compare` and `--two-sided` both reach `readSnapshotPair`, which called `os.ReadFile` on each user-selected `.ndoc` path and only invoked `snapshot.Decode` afterward. That meant the process allocated for the entire file before any snapshot validation occurred, so a corrupt, accidentally huge, or deliberately oversized file could consume arbitrary memory simply because it had a `.ndoc` path.

This introduces `snapshot.MaxArtifactBytes` (16 MiB, chosen above `remote.MaxResponseBytes` at 8 MiB since one snapshot can bundle more data than a single remote response) and reads with `io.LimitReader(f, snapshot.MaxArtifactBytes+1)` instead of `os.ReadFile`, so the actual read stays bounded rather than relying on `Stat().Size()` alone. An oversized artifact is now rejected with a clear, sanitized error identifying the file, before JSON decoding, and retains exit code 2 for an unusable comparison, exactly as with any other unusable artifact. Every legitimately generated snapshot, including watch-incident snapshots, continues to be accepted unchanged since 16 MiB is well above any realistic snapshot size and the format itself declares no smaller maximum shape.

## Validation

- [x] Tests nearest the change pass (`go test ./internal/app ./internal/snapshot ./internal/compare`)
- [x] Normal local validation passed (`./scripts/check`)
- [ ] Full CI gate passed, or the specific checks that did not run are explained below

## Skipped checks

Ran `./scripts/check` only, per the issue's stated validation commands. Did not separately run the full CI gate (race, fuzz, loopback-integration, namespace, acceptance, or container suites, or the pinned external tools) locally.

## Platforms

Tested in a Linux Codespace. `./scripts/check` cross-compiles for darwin and windows and builds a FreeBSD portability stub, but this was not manually run on macOS or Windows.

## TUI changes

Not applicable — no TUI-visible change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Offline snapshot comparisons now enforce a 16 MiB artifact size limit in both comparison modes.
  * Oversized artifacts are rejected with a clear error before being fully loaded into memory.
  * Newly generated snapshots exceeding the supported size limit are rejected.
  * Artifacts produced by watch-incident workflows remain readable through offline tools.
  * Files within the supported size limit continue to be processed normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->